### PR TITLE
feat/#11 git repository  조회

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/config/GlobalCorsConfig.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/config/GlobalCorsConfig.java
@@ -10,7 +10,7 @@ public class GlobalCorsConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("http://localhost:3000") // 프론트 주소
+        .allowedOrigins("http://localhost:5173") // 프론트 주소
         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
         .allowedHeaders("*")
         .allowCredentials(true); // 프론트에서 withCredentials 사용하는 경우 필수

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/service/OAuthService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/service/OAuthService.java
@@ -31,7 +31,7 @@ public class OAuthService {
 
   public String generateGitHubLoginUrl() {
     return String.format(
-        "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=user",
+        "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=user%%20repo",
         clientId, redirectUri
     );
   }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/controller/GitHubRepoController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/controller/GitHubRepoController.java
@@ -1,0 +1,30 @@
+package com.gitprism.GitPRism.repositorys.controller;
+
+import com.gitprism.GitPRism.repositorys.dto.response.GitHubRepoResponse;
+import com.gitprism.GitPRism.repositorys.service.GitHubRepoService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/github-repos")
+@RequiredArgsConstructor
+public class GitHubRepoController {
+
+    private final GitHubRepoService gitHubRepoService;
+
+    @Operation(
+            summary = "내가 참여한 GitHub 레포지토리 조회",
+            description = "DB에 저장된 accessToken으로 GitHub API를 호출하여 사용자가 PR 또는 이슈에 참여한 레포지토리 목록을 가져옵니다."
+    )
+    @GetMapping
+    public ResponseEntity<?> getParticipatedRepos(@RequestParam("userId") Long userId) {
+        // ✅ 새 방식으로 참여한 레포만 가져오기
+        List<GitHubRepoResponse> responseList = gitHubRepoService.getParticipatedRepositories(userId);
+        return ResponseEntity.ok(responseList);
+    }
+}
+

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/dto/request/GitHubTokenRequest.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/dto/request/GitHubTokenRequest.java
@@ -1,0 +1,14 @@
+package com.gitprism.GitPRism.repositorys.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubTokenRequest {
+    private Long userId; // accessToken은 제거
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/dto/response/GitHubRepoResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/dto/response/GitHubRepoResponse.java
@@ -1,0 +1,36 @@
+package com.gitprism.GitPRism.repositorys.dto.response;
+
+import com.gitprism.GitPRism.repositorys.entity.Repo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GitHubRepoResponse {
+    private Long id;
+    private String githubId;
+    private String repoName;
+    private String url;
+    private String description;
+    private String defaultBranch;
+    private String language;
+    private String visibility;
+
+    public static List<GitHubRepoResponse> fromEntities(List<Repo> repos) {
+        return repos.stream().map(repo ->
+                GitHubRepoResponse.builder()
+                        .id(repo.getId())
+                        .githubId(repo.getGithubId())
+                        .repoName(repo.getRepoName())
+                        .url(repo.getUrl())
+                        .description(repo.getDescription())
+                        .defaultBranch(repo.getDefaultBranch())
+                        .language(repo.getLanguage())
+                        .visibility(repo.getVisibility())
+                        .build()
+        ).collect(Collectors.toList());
+    }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/entity/Repo.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/entity/Repo.java
@@ -1,0 +1,61 @@
+package com.gitprism.GitPRism.repositorys.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "repo")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Repo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "git_id")
+    private String githubId; // 또는 userId 등 일치되는 이름
+
+    @Column(name = "repo_name", length = 255)
+    private String repoName;
+
+    @Column(columnDefinition = "TEXT")
+    private String url;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "default_branch", length = 255)
+    private String defaultBranch;
+
+    @Column(length = 255)
+    private String language;
+
+    @Column(length = 50)
+    private String visibility;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted")
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Column(name = "github_repo_id", unique = true)
+    private Long githubRepoId;
+
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/repository/RepoRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/repository/RepoRepository.java
@@ -1,0 +1,15 @@
+package com.gitprism.GitPRism.repositorys.repository;
+
+import com.gitprism.GitPRism.repositorys.entity.Repo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public interface RepoRepository extends JpaRepository<Repo, Long> {
+    List<Repo> findAllByGithubIdAndIsDeletedFalse(String githubId);
+    Optional<Repo> findByGithubRepoId(Long githubRepoId);
+
+    List<Repo> findByGithubId(String githubId);
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/service/GitHubRepoService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/repositorys/service/GitHubRepoService.java
@@ -1,0 +1,121 @@
+package com.gitprism.GitPRism.repositorys.service;
+
+import com.gitprism.GitPRism.repositorys.dto.response.GitHubRepoResponse;
+import com.gitprism.GitPRism.repositorys.entity.Repo;
+import com.gitprism.GitPRism.repositorys.repository.RepoRepository;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GitHubRepoService {
+
+    private final GitHubUserRepository gitHubUserRepository;
+    private final RepoRepository repoRepository;
+    private final ObjectMapper objectMapper;
+
+    private static final String GITHUB_API_URL = "https://api.github.com/user/repos";
+
+    public String getAccessTokenByUserId(Long userId) {
+        GitHubUser user = gitHubUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + userId));
+
+        String accessToken = user.getAccessToken();
+        return user.getAccessToken();
+    }
+
+    @Transactional
+    public List<GitHubRepoResponse> getParticipatedRepositories(Long userId) {
+        GitHubUser user = gitHubUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 유저를 찾을 수 없습니다: " + userId));
+
+        String accessToken = user.getAccessToken();
+        String username = user.getUsername();
+
+        OkHttpClient client = new OkHttpClient();
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 1. 유저 이벤트 호출
+        Request request = new Request.Builder()
+                .url("https://api.github.com/users/" + username + "/events")
+                .header("Authorization", "Bearer " + accessToken)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.error("GitHub 이벤트 조회 실패: {}", response);
+                throw new IOException("GitHub 이벤트 조회 실패: " + response);
+            }
+
+            JsonNode events = mapper.readTree(response.body().string());
+            Set<Long> processedRepoIds = new HashSet<>();
+
+            List<Repo> savedRepos = new ArrayList<>();
+            for (JsonNode event : events) {
+                String type = event.get("type").asText();
+                if (!type.equals("PullRequestEvent") && !type.equals("IssuesEvent")) continue;
+
+                String fullRepoName = event.get("repo").get("name").asText();
+
+
+                // 2. 해당 레포 정보 호출
+                Request repoRequest = new Request.Builder()
+                        .url("https://api.github.com/repos/" + fullRepoName)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .build();
+
+                try (Response repoResponse = client.newCall(repoRequest).execute()) {
+                    if (!repoResponse.isSuccessful()) {
+                        log.warn("레포 정보 조회 실패: {}", fullRepoName);
+                        continue;
+                    }
+
+                    JsonNode repoData = mapper.readTree(repoResponse.body().string());
+
+                    Long githubRepoId = repoData.get("id").asLong();
+                    if (processedRepoIds.contains(githubRepoId)) {
+                        continue;
+                    }
+                    processedRepoIds.add(githubRepoId);
+                    String name = repoData.get("name").asText();
+                    String githubId = repoData.get("id").asText();
+                    String description = repoData.hasNonNull("description") ? repoData.get("description").asText() : null;
+                    String url = repoData.get("html_url").asText();
+                    String visibility = repoData.get("private").asBoolean() ? "private" : "public";
+                    String defaultBranch = repoData.get("default_branch").asText();
+                    String language = repoData.hasNonNull("language") ? repoData.get("language").asText() : null;
+
+
+                    Optional<Repo> existingRepo = repoRepository.findByGithubRepoId(githubRepoId);
+                    Repo repo = existingRepo.orElse(Repo.builder().githubRepoId(githubRepoId).build());
+
+                    repo.setRepoName(name);
+                    repo.setGithubId(user.getUsername());
+                    repo.setDescription(description);
+                    repo.setUrl(url);
+                    repo.setVisibility(visibility);
+                    repo.setDefaultBranch(defaultBranch);
+                    repo.setLanguage(language);
+
+                    savedRepos.add(repoRepository.save(repo));
+                }
+            }
+
+            return GitHubRepoResponse.fromEntities(savedRepos);
+
+        } catch (IOException e) {
+            throw new RuntimeException("참여 레포 조회 실패", e);
+        }
+    }
+}

--- a/GitPRism/src/main/resources/db/migration/V3__add_column_to_git_hub_repo.sql
+++ b/GitPRism/src/main/resources/db/migration/V3__add_column_to_git_hub_repo.sql
@@ -1,0 +1,12 @@
+CREATE TABLE repo (
+                      id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                      git_id VARCHAR(255),
+                      repo_name VARCHAR(255),
+                      url TEXT,
+                      description TEXT,
+                      default_branch VARCHAR(255),
+                      language VARCHAR(255),
+                      created_at TIMESTAMP,
+                      updated_at TIMESTAMP,
+                      is_deleted BOOLEAN
+);


### PR DESCRIPTION
## 🔥 PR 개요
git api 를 이용하여 로그인한 사용자의 참여 이력이 있는 repository 조회, 저장

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [ㅇ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
![{8CCB1569-7D74-4984-8468-E8A2C5AC6814}](https://github.com/user-attachments/assets/090de110-e3b6-40da-b387-77608aa84210)
1. user db 에 저장되어있는 유저의 id 입력
![{8E485A7E-57FB-4F04-9324-BB2E470A2BE7}](https://github.com/user-attachments/assets/0339e0c1-3c4a-468a-af1a-ae35c13abaa5)
2. 이슈와 pr에서 참여이력 조회 -> 조회한 참여 이력을 통해 레포 정보를 가져옴
![{4526F5DF-2A6A-4DB6-9932-A183D8D029A4}](https://github.com/user-attachments/assets/f2da6c7d-c375-4dab-9a1b-7f13d550573e)
3. 데이터베이스에 레포 정보 저장

## ✅ 테스트 방법
swagger에서 조회 가능 단, 로그인이 필수적으로 선행되어야 기능 동작 가능

## 🏷️ 관련 이슈

## 🚀 추가 정보
추후 추가 수정요소 : 레포상세 정보를 추가적으로 가져와 데이터베이스에 저장