### PR TITLE
Feat: 좋아요 등록 및 취소 기능 구현 (알림 + 소프트 삭제 포함)

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/controller/LikeController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/controller/LikeController.java
@@ -1,21 +1,27 @@
 package com.gitprism.GitPRism.likes.controller;
 
 import com.gitprism.GitPRism.likes.service.LikeService;
+import com.gitprism.GitPRism.config.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/portfolios") // ✅ 공통 경로 설정
 public class LikeController {
 
   private final LikeService likeService;
+  private final JwtTokenProvider jwtTokenProvider;
 
-  @PostMapping("/api/v1/portfolios/{portfolioId}/likes")
+  // ✅ 좋아요 등록
+  @PostMapping("/{portfolioId}/likes")
+  @Operation(summary = "좋아요 등록", description = "포트폴리오에 좋아요를 등록합니다.")
   public ResponseEntity<Map<String, Object>> likePortfolio(
       @PathVariable Long portfolioId,
       Authentication authentication
@@ -23,5 +29,17 @@ public class LikeController {
     String githubId = authentication.getName();
     Map<String, Object> response = likeService.addLike(portfolioId, githubId);
     return ResponseEntity.status(201).body(response);
+  }
+
+  // ✅ 좋아요 취소
+  @DeleteMapping("/{portfolioId}/likes")
+  @Operation(summary = "좋아요 취소", description = "특정 포트폴리오에 대해 사용자의 좋아요를 취소합니다.")
+  public ResponseEntity<Map<String, Object>> cancelLike(
+      @Parameter(hidden = true) @RequestHeader("Authorization") String token,
+      @PathVariable Long portfolioId
+  ) {
+    String githubId = jwtTokenProvider.getGithubIdFromToken(token.replace("Bearer ", "").trim());
+    Map<String, Object> result = likeService.cancelLike(portfolioId, githubId);
+    return ResponseEntity.ok(result);
   }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/controller/LikeController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/controller/LikeController.java
@@ -1,0 +1,27 @@
+package com.gitprism.GitPRism.likes.controller;
+
+import com.gitprism.GitPRism.likes.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+  private final LikeService likeService;
+
+  @PostMapping("/api/v1/portfolios/{portfolioId}/likes")
+  public ResponseEntity<Map<String, Object>> likePortfolio(
+      @PathVariable Long portfolioId,
+      Authentication authentication
+  ) {
+    String githubId = authentication.getName();
+    Map<String, Object> response = likeService.addLike(portfolioId, githubId);
+    return ResponseEntity.status(201).body(response);
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/entity/Like.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/entity/Like.java
@@ -1,0 +1,53 @@
+package com.gitprism.GitPRism.likes.entity;
+
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Like {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "portfolio_id", nullable = false)
+  private Portfolio portfolio;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private GitHubUser user;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "is_deleted", nullable = false)
+  private Boolean isDeleted;
+
+  public static Like create(GitHubUser user, Portfolio portfolio) {
+    return Like.builder()
+        .user(user)
+        .portfolio(portfolio)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .isDeleted(false)
+        .build();
+  }
+
+  public void delete() {
+    this.isDeleted = true;
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/entity/Like.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/entity/Like.java
@@ -50,4 +50,9 @@ public class Like {
     this.isDeleted = true;
     this.updatedAt = LocalDateTime.now();
   }
+
+  public void recover() {
+    this.isDeleted = false;
+    this.updatedAt = LocalDateTime.now();
+  }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/event/LikeCreatedEvent.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/event/LikeCreatedEvent.java
@@ -1,0 +1,13 @@
+package com.gitprism.GitPRism.likes.event;
+
+import com.gitprism.GitPRism.likes.entity.Like;
+import lombok.Getter;
+
+@Getter
+public class LikeCreatedEvent {
+  private final Like like;
+
+  public LikeCreatedEvent(Like like) {
+    this.like = like;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/listener/LikeEventListener.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/listener/LikeEventListener.java
@@ -1,0 +1,21 @@
+package com.gitprism.GitPRism.likes.listener;
+
+import com.gitprism.GitPRism.likes.entity.Like;
+import com.gitprism.GitPRism.likes.event.LikeCreatedEvent;
+import com.gitprism.GitPRism.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LikeEventListener {
+
+  private final NotificationService notificationService;
+
+  @EventListener
+  public void handleLikeCreatedEvent(LikeCreatedEvent event) {
+    Like like = event.getLike();
+    notificationService.createNotification(like);
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
@@ -15,4 +15,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
   // 알림 발행 등을 위한 엔티티 조회
   Optional<Like> findByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
 
+  Optional<Like> findByUserAndPortfolio(GitHubUser user, Portfolio portfolio);
+
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
@@ -14,4 +14,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
   // 알림 발행 등을 위한 엔티티 조회
   Optional<Like> findByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
+
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/repository/LikeRepository.java
@@ -1,0 +1,17 @@
+package com.gitprism.GitPRism.likes.repository;
+
+import com.gitprism.GitPRism.likes.entity.Like;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+  // 소프트 삭제 고려해서 중복 여부 확인
+  boolean existsByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
+
+  // 알림 발행 등을 위한 엔티티 조회
+  Optional<Like> findByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -36,33 +36,29 @@ public class LikeService {
     Portfolio portfolio = portfolioRepository.findById(portfolioId)
         .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
 
-    // 🔍 삭제된 좋아요 포함하여 조회
     Like like = likeRepository.findByUserAndPortfolio(user, portfolio).orElse(null);
 
     if (like != null) {
       if (Boolean.FALSE.equals(like.getIsDeleted())) {
         throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
       }
-      // ✅ 소프트 삭제 복구
-      like.recover();
+      like.recover(); // isDeleted = false, updatedAt 수정
     } else {
-      // ✅ 새로 등록
       like = Like.create(user, portfolio);
       likeRepository.save(like);
     }
 
-    // 🔔 이벤트 발행 (알림 전송용)
+    // 🔔 알림 전송
     eventPublisher.publishEvent(new LikeCreatedEvent(like));
 
-    // ✅ 응답 반환
-    Map<String, Object> response = new LinkedHashMap<>();
-    response.put("message", "좋아요가 등록되었습니다.");
-    response.put("code", 201);
-    response.put("portfolio_id", portfolioId);
-    response.put("user_id", user.getId());
-
-    return response;
+    return Map.of(
+        "message", "좋아요가 추가되었습니다.",
+        "code", 201,
+        "portfolio_id", portfolioId,
+        "user_id", user.getId()
+    );
   }
+
 
   @Transactional
   public Map<String, Object> cancelLike(Long portfolioId, String githubId) {

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -1,0 +1,57 @@
+package com.gitprism.GitPRism.likes.service;
+
+import com.gitprism.GitPRism.likes.entity.Like;
+import com.gitprism.GitPRism.likes.event.LikeCreatedEvent;
+import com.gitprism.GitPRism.likes.repository.LikeRepository;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Map;
+import java.util.LinkedHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+  private final LikeRepository likeRepository;
+  private final GitHubUserRepository userRepository;
+  private final PortfolioRepository portfolioRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public Map<String, Object> addLike(Long portfolioId, String githubId) {
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    Portfolio portfolio = portfolioRepository.findById(portfolioId)
+        .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
+
+    boolean exists = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
+    if (exists) throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+
+    Like like = Like.builder()
+        .user(user)
+        .portfolio(portfolio)
+        .build();
+    likeRepository.save(like);
+
+    // 🔔 알림 발행
+    eventPublisher.publishEvent(new LikeCreatedEvent(like));
+
+    // ✅ 응답 구성
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("message", "좋아요가 추가되었습니다.");
+    response.put("code", 201);
+    response.put("portfolio_id", portfolioId);
+    response.put("user_id", user.getId());
+
+    return response;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -26,7 +26,7 @@ public class LikeService {
   private final ApplicationEventPublisher eventPublisher;
 
   /**
-   * ✅ 좋아요 생성
+   * ✅ 좋아요 생성 및 복구
    */
   @Transactional
   public Map<String, Object> addLike(Long portfolioId, String githubId) {
@@ -36,24 +36,27 @@ public class LikeService {
     Portfolio portfolio = portfolioRepository.findById(portfolioId)
         .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
 
-    boolean exists = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
-    if (exists) {
-      throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
-    }
+    // 🔍 삭제된 좋아요 포함하여 조회
+    Like like = likeRepository.findByUserAndPortfolio(user, portfolio).orElse(null);
 
-    Like like = Like.builder()
-        .user(user)
-        .portfolio(portfolio)
-        .isDeleted(false)
-        .build();
-    likeRepository.save(like);
+    if (like != null) {
+      if (Boolean.FALSE.equals(like.getIsDeleted())) {
+        throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+      }
+      // ✅ 소프트 삭제 복구
+      like.recover();
+    } else {
+      // ✅ 새로 등록
+      like = Like.create(user, portfolio);
+      likeRepository.save(like);
+    }
 
     // 🔔 이벤트 발행 (알림 전송용)
     eventPublisher.publishEvent(new LikeCreatedEvent(like));
 
     // ✅ 응답 반환
     Map<String, Object> response = new LinkedHashMap<>();
-    response.put("message", "좋아요가 추가되었습니다.");
+    response.put("message", "좋아요가 등록되었습니다.");
     response.put("code", 201);
     response.put("portfolio_id", portfolioId);
     response.put("user_id", user.getId());

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -12,9 +12,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
-import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +25,9 @@ public class LikeService {
   private final PortfolioRepository portfolioRepository;
   private final ApplicationEventPublisher eventPublisher;
 
+  /**
+   * ✅ 좋아요 생성
+   */
   @Transactional
   public Map<String, Object> addLike(Long portfolioId, String githubId) {
     GitHubUser user = userRepository.findByGithubId(githubId)
@@ -34,18 +37,21 @@ public class LikeService {
         .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
 
     boolean exists = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
-    if (exists) throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+    if (exists) {
+      throw new IllegalStateException("이미 좋아요를 눌렀습니다.");
+    }
 
     Like like = Like.builder()
         .user(user)
         .portfolio(portfolio)
+        .isDeleted(false)
         .build();
     likeRepository.save(like);
 
-    // 🔔 알림 발행
+    // 🔔 이벤트 발행 (알림 전송용)
     eventPublisher.publishEvent(new LikeCreatedEvent(like));
 
-    // ✅ 응답 구성
+    // ✅ 응답 반환
     Map<String, Object> response = new LinkedHashMap<>();
     response.put("message", "좋아요가 추가되었습니다.");
     response.put("code", 201);

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -60,4 +60,26 @@ public class LikeService {
 
     return response;
   }
+
+  @Transactional
+  public Map<String, Object> cancelLike(Long portfolioId, String githubId) {
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    Portfolio portfolio = portfolioRepository.findById(portfolioId)
+        .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
+
+    Like like = likeRepository.findByUserAndPortfolioAndIsDeletedFalse(user, portfolio)
+        .orElseThrow(() -> new NoSuchElementException("좋아요 기록이 존재하지 않습니다."));
+
+    like.delete();
+
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("message", "좋아요가 취소되었습니다.");
+    response.put("code", 200);
+    response.put("portfolio_id", portfolioId);
+    response.put("user_id", user.getId());
+
+    return response;
+  }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/entity/Notification.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/entity/Notification.java
@@ -1,0 +1,80 @@
+package com.gitprism.GitPRism.notification.entity;
+
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 알림 받는 사용자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private GitHubUser user;
+
+  // 알림 발생시킨 사용자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_id", nullable = false)
+  private GitHubUser sender;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "portfolio_id", nullable = false)
+  private Portfolio portfolio;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  @Column(columnDefinition = "TEXT")
+  private String message;
+
+  private Boolean isRead;
+  private String redirectUrl;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  private Boolean isDeleted;
+
+  public static Notification create(GitHubUser receiver, GitHubUser sender,
+                                    Portfolio portfolio, NotificationType type,
+                                    String message, String redirectUrl) {
+    return Notification.builder()
+        .user(receiver)
+        .sender(sender)
+        .portfolio(portfolio)
+        .type(type)
+        .message(message)
+        .redirectUrl(redirectUrl)
+        .isRead(false)
+        .isDeleted(false)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  public void markAsRead() {
+    this.isRead = true;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public void delete() {
+    this.isDeleted = true;
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/entity/NotificationType.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/entity/NotificationType.java
@@ -1,0 +1,7 @@
+package com.gitprism.GitPRism.notification.entity;
+
+public enum NotificationType {
+  COMMENT_CREATED,
+  LIKE_ADDED,
+  BOOKMARK_ADDED
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/repository/NotificationRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.gitprism.GitPRism.notification.repository;
+
+import com.gitprism.GitPRism.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
@@ -1,17 +1,42 @@
 package com.gitprism.GitPRism.notification.service;
 
 import com.gitprism.GitPRism.comments.entity.Comment;
+import com.gitprism.GitPRism.likes.entity.Like;
+import com.gitprism.GitPRism.notification.entity.Notification;
+import com.gitprism.GitPRism.notification.entity.NotificationType;
+import com.gitprism.GitPRism.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@RequiredArgsConstructor
 @Slf4j
 @Service
 public class NotificationService {
 
-  public void createNotification(Comment comment) {
-    log.info("알림 생성 - portfolioId: {}, userId: {}",
-        comment.getPortfolio().getId(), comment.getUser().getId());
+  private final NotificationRepository notificationRepository;
 
-    // TODO: 알림 저장 또는 WebSocket 전송
+  public void createNotification(Comment comment) {
+    Notification notification = Notification.create(
+        comment.getPortfolio().getUser(),
+        comment.getUser(),
+        comment.getPortfolio(),
+        NotificationType.COMMENT_CREATED,
+        comment.getUser().getUsername() + "님이 댓글을 남겼습니다.",
+        "/portfolios/" + comment.getPortfolio().getId()
+    );
+    notificationRepository.save(notification);
+  }
+
+  public void createNotification(Like like) {
+    Notification notification = Notification.create(
+        like.getPortfolio().getUser(),
+        like.getUser(),
+        like.getPortfolio(),
+        NotificationType.LIKE_ADDED,
+        like.getUser().getUsername() + "님이 좋아요를 눌렀습니다.",
+        "/portfolios/" + like.getPortfolio().getId()
+    );
+    notificationRepository.save(notification);
   }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/entity/Portfolio.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/entity/Portfolio.java
@@ -2,7 +2,7 @@ package com.gitprism.GitPRism.portfolios.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
 import java.time.LocalDateTime;
 
 @Entity
@@ -17,8 +17,10 @@ public class Portfolio {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "user_id", nullable = false)
-  private Long userId;
+  // ManyToOne으로 작성자 참조
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private GitHubUser user;
 
   private String title;
   private String description;

--- a/GitPRism/src/main/resources/db/migration/V8__create_likes_table.sql
+++ b/GitPRism/src/main/resources/db/migration/V8__create_likes_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE likes (
+                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       portfolio_id BIGINT NOT NULL,
+                       user_id BIGINT NOT NULL,
+                       created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                       updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                       is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+
+                       CONSTRAINT fk_likes_portfolio
+                           FOREIGN KEY (portfolio_id) REFERENCES portfolios(id)
+                               ON DELETE CASCADE,
+
+                       CONSTRAINT fk_likes_user
+                           FOREIGN KEY (user_id) REFERENCES github_users(id)
+                               ON DELETE CASCADE
+);
+
+-- 인덱스 추가 (성능 향상)
+CREATE INDEX idx_likes_user_id ON likes(user_id);
+CREATE INDEX idx_likes_portfolio_id ON likes(portfolio_id);

--- a/GitPRism/src/main/resources/db/migration/V9__create_notification_table.sql
+++ b/GitPRism/src/main/resources/db/migration/V9__create_notification_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE notifications (
+                               id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+                               user_id BIGINT NOT NULL,              -- 알림 받는 사람
+                               sender_id BIGINT NOT NULL,            -- 알림 보낸 사람
+                               portfolio_id BIGINT NOT NULL,         -- 알림 대상 포트폴리오
+
+                               type ENUM('COMMENT_CREATED', 'LIKE_ADDED', 'BOOKMARK_ADDED') NOT NULL COMMENT '알림 타입',
+
+                               message TEXT,                         -- 알림 캐시 메시지 (선택)
+                               is_read BOOLEAN NOT NULL DEFAULT FALSE,
+                               redirect_url VARCHAR(255),            -- 클릭 시 이동 경로 (ex: /portfolios/1)
+
+                               created_at DATETIME NOT NULL,
+                               updated_at DATETIME NOT NULL,
+                               is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+
+                               CONSTRAINT fk_notifications_user FOREIGN KEY (user_id) REFERENCES github_users (id),
+                               CONSTRAINT fk_notifications_sender FOREIGN KEY (sender_id) REFERENCES github_users (id),
+                               CONSTRAINT fk_notifications_portfolio FOREIGN KEY (portfolio_id) REFERENCES portfolios (id)
+);


### PR DESCRIPTION
## 🔥 PR 개요
포트폴리오 좋아요 등록 및 취소 기능 구현 (알림 + 소프트 삭제 포함)

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [x] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
- 사용자가 특정 포트폴리오에 좋아요를 등록하거나 취소할 수 있는 기능 추가
- 소프트 삭제 방식을 도입하여 중복 방지 및 복구 기능 구현
- 좋아요 발생 시 알림 전송 기능도 함께 처리

## 🛠️사용 기술
- Spring Boot, Spring Security, JWT 인증 기반 사용자 추출
- JPA (ManyToOne, Soft Delete 구현)
- @Transactional, @EventListener
- ApplicationEventPublisher로 비동기 알림 전파

🤔 고민한 점 & 해결 방법
1. 좋아요 중복 처리 어떻게 할까?
좋아요를 여러 번 누를 수 없도록 제한해야 했습니다.
하지만 단순히 중복 체크만 하면, 소프트 삭제된 좋아요는 무시되므로 복구가 어려움.

✅ 해결:
- existsByUserAndPortfolioAndIsDeletedFalse()로 중복 여부 확인
- findByUserAndPortfolio()로 삭제된 상태 포함 조회 → 있으면 복구 처리

2. 소프트 삭제 vs 하드 삭제
- 삭제 후 다시 좋아요 누르면 새로운 row가 생겨야 할까?
- 기존 알림과 데이터 추적을 위해 소프트 삭제 방식이 더 적절하다고 판단

✅ 해결:
- Like 엔티티에 isDeleted, updatedAt 필드 도입
- like.delete(), like.recover() 메서드로 상태 관리

3. 알림은 언제, 어떻게 보낼까?
- 단순히 좋아요 누를 때뿐 아니라 복구될 때도 알림이 가야 함
-이벤트 방식으로 처리하여 서비스 로직과 알림 로직을 분리

✅ 해결:
- LikeCreatedEvent 정의 후 ApplicationEventPublisher.publishEvent()로 이벤트 발행
- LikeEventListener에서 @EventListener로 알림 생성 및 저장

## 📷 스크린샷 (선택)
- [DELETE]
![image](https://github.com/user-attachments/assets/450c65c4-b957-4b7a-8877-2b5fa7019d7e)

- [POST]
![image](https://github.com/user-attachments/assets/3f674668-4a0f-43dc-ba33-511a44722e5b)

[알림]
![image](https://github.com/user-attachments/assets/5dd7128d-01f6-4933-966c-13f6c132961e)
![image](https://github.com/user-attachments/assets/a43115b2-154f-4dd2-b51c-5310c92b105e)
![image](https://github.com/user-attachments/assets/e0a4c5e5-2583-475e-94cc-bf2d7894b8f6)

## 🏷️ 관련 이슈
#23 