### PR TITLE
feat: 북마크 등록, 취소, 목록 조회 기능 구현

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.gitprism.GitPRism.bookmarks.controller;
 
 import com.gitprism.GitPRism.bookmarks.service.BookmarkService;
+import com.gitprism.GitPRism.bookmarks.dto.BookmarkListResponse;
 import com.gitprism.GitPRism.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,14 @@ public class BookmarkController {
     Map<String, Object> result = bookmarkService.addBookmark(portfolioId, githubId);
     return ResponseEntity.status(201).body(result);
   }
+
+  @GetMapping("/bookmarks/me")
+  public ResponseEntity<BookmarkListResponse> getMyBookmarks(Authentication authentication) {
+    String githubId = authentication.getName();
+    BookmarkListResponse response = bookmarkService.getMyBookmarks(githubId);
+    return ResponseEntity.ok(response);
+  }
+
   @DeleteMapping("/{portfolioId}/bookmarks")
   public ResponseEntity<Map<String, Object>> cancelBookmark(
       @PathVariable Long portfolioId,

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
@@ -1,0 +1,29 @@
+package com.gitprism.GitPRism.bookmarks.controller;
+
+import com.gitprism.GitPRism.bookmarks.service.BookmarkService;
+import com.gitprism.GitPRism.config.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/portfolios")
+public class BookmarkController {
+
+  private final BookmarkService bookmarkService;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @PostMapping("/{portfolioId}/bookmarks")
+  public ResponseEntity<Map<String, Object>> addBookmark(
+      @PathVariable Long portfolioId,
+      Authentication authentication
+  ) {
+    String githubId = authentication.getName();
+    Map<String, Object> result = bookmarkService.addBookmark(portfolioId, githubId);
+    return ResponseEntity.status(201).body(result);
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/controller/BookmarkController.java
@@ -26,4 +26,13 @@ public class BookmarkController {
     Map<String, Object> result = bookmarkService.addBookmark(portfolioId, githubId);
     return ResponseEntity.status(201).body(result);
   }
+  @DeleteMapping("/{portfolioId}/bookmarks")
+  public ResponseEntity<Map<String, Object>> cancelBookmark(
+      @PathVariable Long portfolioId,
+      Authentication authentication
+  ) {
+    String githubId = authentication.getName();
+    Map<String, Object> result = bookmarkService.cancelBookmark(portfolioId, githubId);
+    return ResponseEntity.ok(result);
+  }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/dto/BookmarkListResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/dto/BookmarkListResponse.java
@@ -1,0 +1,24 @@
+package com.gitprism.GitPRism.bookmarks.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BookmarkListResponse {
+  private String message;
+  private int code;
+  private List<BookmarkSimpleDto> bookmarks;
+
+  @Getter
+  @AllArgsConstructor
+  public static class BookmarkSimpleDto {
+    private Long portfolioId;
+    private String title;
+    private String description;
+    private LocalDateTime createdAt;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/entity/Bookmark.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/entity/Bookmark.java
@@ -1,0 +1,58 @@
+package com.gitprism.GitPRism.bookmarks.entity;
+
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "bookmarks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Bookmark {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private GitHubUser user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "portfolio_id", nullable = false)
+  private Portfolio portfolio;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted;
+
+  public static Bookmark create(GitHubUser user, Portfolio portfolio) {
+    return Bookmark.builder()
+        .user(user)
+        .portfolio(portfolio)
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .isDeleted(false)
+        .build();
+  }
+
+  public void delete() {
+    this.isDeleted = true;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public void recover() {
+    this.isDeleted = false;
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/event/BookmarkCreatedEvent.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/event/BookmarkCreatedEvent.java
@@ -1,0 +1,13 @@
+package com.gitprism.GitPRism.bookmarks.event;
+
+import com.gitprism.GitPRism.bookmarks.entity.Bookmark;
+import lombok.Getter;
+
+@Getter
+public class BookmarkCreatedEvent {
+  private final Bookmark bookmark;
+
+  public BookmarkCreatedEvent(Bookmark bookmark) {
+    this.bookmark = bookmark;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/listener/BookmarkEventListener.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/listener/BookmarkEventListener.java
@@ -1,0 +1,22 @@
+package com.gitprism.GitPRism.bookmarks.listener;
+
+import com.gitprism.GitPRism.bookmarks.event.BookmarkCreatedEvent;
+import com.gitprism.GitPRism.notification.entity.Notification;
+import com.gitprism.GitPRism.notification.entity.NotificationType;
+import com.gitprism.GitPRism.notification.repository.NotificationRepository;
+import com.gitprism.GitPRism.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BookmarkEventListener {
+
+  private final NotificationService notificationService;
+
+  @EventListener
+  public void handleBookmarkCreated(BookmarkCreatedEvent event) {
+    notificationService.createNotification(event.getBookmark());
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
@@ -5,10 +5,12 @@ import com.gitprism.GitPRism.github_users.entity.GitHubUser;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   boolean existsByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
   Optional<Bookmark> findByUserAndPortfolio(GitHubUser user, Portfolio portfolio);
   Optional<Bookmark> findByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
+  List<Bookmark> findAllByUserAndIsDeletedFalseOrderByCreatedAtDesc(GitHubUser user);
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   boolean existsByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
   Optional<Bookmark> findByUserAndPortfolio(GitHubUser user, Portfolio portfolio);
+  Optional<Bookmark> findByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/repository/BookmarkRepository.java
@@ -1,0 +1,13 @@
+package com.gitprism.GitPRism.bookmarks.repository;
+
+import com.gitprism.GitPRism.bookmarks.entity.Bookmark;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+  boolean existsByUserAndPortfolioAndIsDeletedFalse(GitHubUser user, Portfolio portfolio);
+  Optional<Bookmark> findByUserAndPortfolio(GitHubUser user, Portfolio portfolio);
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
@@ -54,4 +54,30 @@ public class BookmarkService {
         "user_id", user.getId()
     );
   }
+
+  @Transactional
+  public Map<String, Object> cancelBookmark(Long portfolioId, String githubId) {
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    Portfolio portfolio = portfolioRepository.findById(portfolioId)
+        .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
+
+    Bookmark bookmark = bookmarkRepository.findByUserAndPortfolio(user, portfolio)
+        .orElseThrow(() -> new NoSuchElementException("북마크 기록이 존재하지 않습니다."));
+
+    if (bookmark.isDeleted()) {
+      throw new IllegalStateException("이미 취소된 북마크입니다.");
+    }
+
+    bookmark.delete();
+
+    return Map.of(
+        "message", "북마크가 취소되었습니다.",
+        "code", 200,
+        "portfolio_id", portfolioId,
+        "user_id", user.getId()
+    );
+  }
+
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
@@ -1,0 +1,57 @@
+package com.gitprism.GitPRism.bookmarks.service;
+
+import com.gitprism.GitPRism.bookmarks.entity.Bookmark;
+import com.gitprism.GitPRism.bookmarks.repository.BookmarkRepository;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
+import com.gitprism.GitPRism.bookmarks.event.BookmarkCreatedEvent;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+  private final BookmarkRepository bookmarkRepository;
+  private final GitHubUserRepository userRepository;
+  private final PortfolioRepository portfolioRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public Map<String, Object> addBookmark(Long portfolioId, String githubId) {
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    Portfolio portfolio = portfolioRepository.findById(portfolioId)
+        .orElseThrow(() -> new NoSuchElementException("포트폴리오를 찾을 수 없습니다."));
+
+    Bookmark bookmark = bookmarkRepository.findByUserAndPortfolio(user, portfolio).orElse(null);
+
+    if (bookmark != null) {
+      if (!bookmark.isDeleted()) {
+        throw new IllegalStateException("이미 북마크한 포트폴리오입니다.");
+      }
+      bookmark.recover();
+    } else {
+      bookmark = Bookmark.create(user, portfolio);
+      bookmarkRepository.save(bookmark);
+    }
+
+    eventPublisher.publishEvent(new BookmarkCreatedEvent(bookmark));
+
+    return Map.of(
+        "message", "북마크가 추가되었습니다.",
+        "code", 201,
+        "portfolio_id", portfolioId,
+        "user_id", user.getId()
+    );
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
@@ -7,12 +7,14 @@ import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
 import com.gitprism.GitPRism.bookmarks.event.BookmarkCreatedEvent;
+import com.gitprism.GitPRism.bookmarks.dto.BookmarkListResponse;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -78,6 +80,25 @@ public class BookmarkService {
         "portfolio_id", portfolioId,
         "user_id", user.getId()
     );
+  }
+
+  @Transactional(readOnly = true)
+  public BookmarkListResponse getMyBookmarks(String githubId) {
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    List<Bookmark> bookmarks = bookmarkRepository.findAllByUserAndIsDeletedFalseOrderByCreatedAtDesc(user);
+
+    List<BookmarkListResponse.BookmarkSimpleDto> result = bookmarks.stream()
+        .map(b -> new BookmarkListResponse.BookmarkSimpleDto(
+            b.getPortfolio().getId(),
+            b.getPortfolio().getTitle(),
+            b.getPortfolio().getDescription(),
+            b.getCreatedAt()
+        ))
+        .toList();
+
+    return new BookmarkListResponse("북마크 목록 조회 성공", 200, result);
   }
 
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
@@ -2,9 +2,12 @@ package com.gitprism.GitPRism.notification.service;
 
 import com.gitprism.GitPRism.comments.entity.Comment;
 import com.gitprism.GitPRism.likes.entity.Like;
+import com.gitprism.GitPRism.bookmarks.entity.Bookmark;
 import com.gitprism.GitPRism.notification.entity.Notification;
 import com.gitprism.GitPRism.notification.entity.NotificationType;
 import com.gitprism.GitPRism.notification.repository.NotificationRepository;
+
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,6 +39,18 @@ public class NotificationService {
         NotificationType.LIKE_ADDED,
         like.getUser().getUsername() + "님이 좋아요를 눌렀습니다.",
         "/portfolios/" + like.getPortfolio().getId()
+    );
+    notificationRepository.save(notification);
+  }
+
+  public void createNotification(Bookmark bookmark) {
+    Notification notification = Notification.create(
+        bookmark.getPortfolio().getUser(), // 알림 받을 사람 (포트폴리오 주인)
+        bookmark.getUser(),                // 북마크한 사람
+        bookmark.getPortfolio(),
+        NotificationType.BOOKMARK_ADDED,
+        bookmark.getUser().getUsername() + "님이 포트폴리오를 북마크했습니다.",
+        "/portfolios/" + bookmark.getPortfolio().getId()
     );
     notificationRepository.save(notification);
   }

--- a/GitPRism/src/main/resources/db/migration/V10__create_bookmarks_table.sql
+++ b/GitPRism/src/main/resources/db/migration/V10__create_bookmarks_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE bookmarks (
+                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                           user_id BIGINT NOT NULL,
+                           portfolio_id BIGINT NOT NULL,
+                           is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                           created_at DATETIME NOT NULL,
+                           updated_at DATETIME NOT NULL,
+
+                           CONSTRAINT fk_bookmark_user
+                               FOREIGN KEY (user_id)
+                                   REFERENCES github_users (id)
+                                   ON DELETE CASCADE,
+
+                           CONSTRAINT fk_bookmark_portfolio
+                               FOREIGN KEY (portfolio_id)
+                                   REFERENCES portfolios (id)
+                                   ON DELETE CASCADE
+);


### PR DESCRIPTION
## 🔥 PR 개요
- 사용자가 포트폴리오를 북마크할 수 있는 기능 추가
- 북마크 등록/취소 시 알림 생성 (이벤트 기반 처리)
- 로그인한 사용자의 북마크 전체 목록 조회 기능 구현

## 🎯 변경 사항
- [x] 🚀 기능 추가 (Feature)

## 🤔 고민한 점 & 해결 방법
**1. 북마크 중복 등록 시 어떻게 처리할까?**
❓ 문제
- 사용자가 이미 북마크한 포트폴리오에 다시 북마크 요청을 보낼 수 있음.
- 무조건 새로운 row를 생성하면 중복되고, 기존 알림이나 이력 추적에 혼선이 생김
💡 해결 방향
- 소프트 삭제(Soft Delete) 방식을 활용하여 이미 북마크한 적 있는 경우, row는 그대로 두고 isDeleted 상태만 전환
- 실제로 DB에 존재하지만 isDeleted = true인 경우엔 복구 처리(recover() 메서드)

✅ 구현 방식
- findByUserAndPortfolio() → 북마크 기록 유무 판단
- bookmark.recover()로 복구
- 처음이라면 Bookmark.create()로 새로 저장

**2. 알림 처리를 어디서, 어떻게 분리할까?**
❓ 문제
- 북마크 등록 시 포트폴리오 작성자에게 알림을 보내야 하는데,
서비스 로직에 직접 NotificationRepository.save()를 넣으면 관심사 분리가 안 됨.
- 추후 좋아요/댓글/팔로우 등 다른 알림 기능이 추가되면 코드 중복/혼란이 생김.

💡 해결 방향
- 이벤트 기반 처리 (Spring Event) 방식으로 "북마크 등록"과 "알림 생성"을 명확하게 분리
- 이벤트 클래스 BookmarkCreatedEvent를 만들고 리스너 BookmarkEventListener에서 알림 생성 책임 전담

✅ 구현 방식
- eventPublisher.publishEvent(new BookmarkCreatedEvent(bookmark));
- @EventListener로 알림 생성
- 실제 알림 저장은 NotificationService#createNotification(Bookmark)로 위임

## 📷 스크린샷 (선택)
**[DELETE]**
![image](https://github.com/user-attachments/assets/c7dfb569-36e1-4853-a86c-352c78283812)

**[POST**
![image](https://github.com/user-attachments/assets/ee7735e5-c09e-4560-9c5d-bd8f49917702)

**[GET]**
![image](https://github.com/user-attachments/assets/42efb319-23f3-46e7-a07f-a91f27b228db)

## 🏷️ 관련 이슈
연관된 이슈 번호를 태그해주세요.  
#27 

