### PR TITLE
Feat: 알림 읽음 처리 기능 구현 (알림 목록 조회, 단건 읽음 처리 포함)

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/controller/NotificationController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/controller/NotificationController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +28,18 @@ public class NotificationController {
 
     return ResponseEntity.ok(notificationService.getMyNotifications(user));
   }
+
+  @PatchMapping("/{notificationId}/read")
+  public ResponseEntity<Map<String, Object>> markAsRead(
+      @PathVariable Long notificationId,
+      Authentication authentication
+  ) {
+    String githubId = authentication.getName();
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    Map<String, Object> result = notificationService.markAsRead(notificationId, user);
+    return ResponseEntity.ok(result);
+  }
+
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/controller/NotificationController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/controller/NotificationController.java
@@ -1,0 +1,30 @@
+package com.gitprism.GitPRism.notification.controller;
+
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
+import com.gitprism.GitPRism.notification.dto.NotificationListResponse;
+import com.gitprism.GitPRism.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+  private final GitHubUserRepository userRepository;
+
+  @GetMapping
+  public ResponseEntity<NotificationListResponse> getMyNotifications(Authentication authentication) {
+    String githubId = authentication.getName();
+    GitHubUser user = userRepository.findByGithubId(githubId)
+        .orElseThrow(() -> new NoSuchElementException("GitHub 사용자를 찾을 수 없습니다."));
+
+    return ResponseEntity.ok(notificationService.getMyNotifications(user));
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/dto/NotificationListResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/dto/NotificationListResponse.java
@@ -1,0 +1,28 @@
+package com.gitprism.GitPRism.notification.dto;
+
+import com.gitprism.GitPRism.notification.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NotificationListResponse {
+  private String message;
+  private int code;
+  private List<NotificationDto> notifications;
+
+  @Getter
+  @AllArgsConstructor
+  public static class NotificationDto {
+    private Long notificationId;
+    private NotificationType type;
+    private String message;
+    private Long portfolioId;
+    private String redirectUrl;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/repository/NotificationRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.gitprism.GitPRism.notification.repository;
 
 import com.gitprism.GitPRism.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+  List<Notification> findAllByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(Long userId);
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
@@ -8,12 +8,16 @@ import com.gitprism.GitPRism.notification.entity.NotificationType;
 import com.gitprism.GitPRism.notification.repository.NotificationRepository;
 import com.gitprism.GitPRism.github_users.entity.GitHubUser;
 import com.gitprism.GitPRism.notification.dto.NotificationListResponse;
+
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
+
 import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -76,5 +80,27 @@ public class NotificationService {
         .toList();
 
     return new NotificationListResponse("알림 목록 조회 성공", 200, results);
+  }
+
+  @Transactional
+  public Map<String, Object> markAsRead(Long notificationId, GitHubUser user) {
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new NoSuchElementException("알림을 찾을 수 없습니다."));
+
+    if (!notification.getUser().getId().equals(user.getId())) {
+      throw new IllegalArgumentException("본인의 알림만 읽음 처리할 수 있습니다.");
+    }
+
+    if (notification.getIsDeleted()) {
+      throw new IllegalStateException("삭제된 알림은 처리할 수 없습니다.");
+    }
+
+    notification.markAsRead();
+
+    return Map.of(
+        "message", "알림이 읽음 처리되었습니다.",
+        "code", 200,
+        "notificationId", notification.getId()
+    );
   }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/notification/service/NotificationService.java
@@ -6,11 +6,14 @@ import com.gitprism.GitPRism.bookmarks.entity.Bookmark;
 import com.gitprism.GitPRism.notification.entity.Notification;
 import com.gitprism.GitPRism.notification.entity.NotificationType;
 import com.gitprism.GitPRism.notification.repository.NotificationRepository;
-
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
+import com.gitprism.GitPRism.notification.dto.NotificationListResponse;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -53,5 +56,25 @@ public class NotificationService {
         "/portfolios/" + bookmark.getPortfolio().getId()
     );
     notificationRepository.save(notification);
+  }
+
+  @Transactional(readOnly = true)
+  public NotificationListResponse getMyNotifications(GitHubUser user) {
+    List<Notification> notifications = notificationRepository
+        .findAllByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(user.getId());
+
+    List<NotificationListResponse.NotificationDto> results = notifications.stream()
+        .map(n -> new NotificationListResponse.NotificationDto(
+            n.getId(),
+            n.getType(),
+            n.getMessage(),
+            n.getPortfolio().getId(),
+            n.getRedirectUrl(),
+            n.getIsRead(),
+            n.getCreatedAt()
+        ))
+        .toList();
+
+    return new NotificationListResponse("알림 목록 조회 성공", 200, results);
   }
 }


### PR DESCRIPTION
## 🔥 PR 개요
알림 읽음 처리 기능 구현
(알림 목록 조회, 단건 읽음 처리 포함)

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
- 알림 목록 조회 API 구현 (GET /api/v1/notifications)
- 알림 단건 읽음 처리 API 구현 (PATCH /api/v1/notifications/{notificationId}/read)

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/38974360-5128-461e-88b1-b8b0216cf10e)
![image](https://github.com/user-attachments/assets/a8b511a3-38a7-4a6b-b9c2-1eb49f9560e4)


## 🏷️ 관련 이슈
연관된 이슈 번호를 태그해주세요.  
#31 
