### PR TITLE
feat: 인기 포트폴리오 기능 구현 (Redis Zset기반 점수 누적 및 조회)

### DIFF
--- a/GitPRism/Dockerfile
+++ b/GitPRism/Dockerfile
@@ -1,36 +1,27 @@
 # 🔹 1. 빌드 단계 (Builder Stage)
 FROM openjdk:17-jdk-slim as builder
-
-# 작업 디렉토리 설정
 WORKDIR /app
 
-# Gradle Wrapper와 프로젝트 관련 파일을 먼저 복사
-COPY gradlew ./
+COPY gradlew .
 COPY gradle/ gradle/
 COPY build.gradle settings.gradle ./
-
-# Gradle 종속성 캐싱 (필수 의존성만 먼저 다운로드)
 RUN chmod +x gradlew
 RUN ./gradlew dependencies --no-daemon || true
-
-# 애플리케이션 코드 복사 및 빌드
 COPY . .
 RUN ./gradlew bootJar --no-daemon
 
 # 🔹 2. 실행 단계 (Final Stage)
 FROM openjdk:17-jdk-slim
-
-# 작업 디렉토리 설정
 WORKDIR /app
 
-# 빌드된 JAR 파일 복사 (정확한 파일명 사용)
 COPY --from=builder /app/build/libs/*.jar app.jar
 
-# 애플리케이션 실행 포트 노출
+# ✅ JAR 외부에서 application.yml을 override하도록 복사
+COPY src/main/resources/application.yml ./config/application.yml
+
+# ✅ 포트 노출
 EXPOSE 8080
 
-# 실행 환경 변수 설정 (필요하면 추가 가능)
-ENV SPRING_PROFILES_ACTIVE=prod
-
-# 컨테이너 실행 시 JAR 파일 실행
+# ✅ 🔥 최종 실행 명령
 CMD ["java", "-jar", "app.jar"]
+

--- a/GitPRism/build.gradle
+++ b/GitPRism/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/GitPRism/docker-compose.yml
+++ b/GitPRism/docker-compose.yml
@@ -16,13 +16,29 @@ services:
       - db_data:/var/lib/mysql
     networks:
       - gitprism-network
-    restart: always  # 추가
+    restart: always
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 20
       start_period: 40s
+
+  redis:
+    image: redis:7
+    container_name: gitprism-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - gitprism-network
+    restart: always
+    healthcheck:
+      test: [ "CMD", "sh", "-c", "redis-cli ping | grep PONG" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
 
   flyway:
     image: flyway/flyway:11.4.0
@@ -48,10 +64,12 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: spring-backend
-    restart: always  # 추가
+    restart: always
     depends_on:
       flyway:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -59,6 +77,8 @@ services:
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql-db:3306/${MYSQL_DATABASE}?serverTimezone=UTC&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
       SPRING_FLYWAY_ENABLED: "false"
+      SPRING_REDIS_HOST: ${SPRING_REDIS_HOST}
+      SPRING_REDIS_PORT: ${SPRING_REDIS_PORT}
     networks:
       - gitprism-network
 

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/bookmarks/service/BookmarkService.java
@@ -9,6 +9,8 @@ import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
 import com.gitprism.GitPRism.bookmarks.event.BookmarkCreatedEvent;
 import com.gitprism.GitPRism.bookmarks.dto.BookmarkListResponse;
 import com.gitprism.GitPRism.bookmarks.dto.BookmarkStatusResponse;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreEvent;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreType;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,6 +52,7 @@ public class BookmarkService {
 
     eventPublisher.publishEvent(new BookmarkCreatedEvent(bookmark));
 
+    eventPublisher.publishEvent(new PortfolioScoreEvent(portfolioId, PortfolioScoreType.BOOKMARK));
     return Map.of(
         "message", "북마크가 추가되었습니다.",
         "code", 201,

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/comments/service/CommentService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/comments/service/CommentService.java
@@ -10,6 +10,8 @@ import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
 import com.gitprism.GitPRism.comments.dto.CommentListResponseDto;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreEvent;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +47,8 @@ public class CommentService {
 
     // 📣 이벤트 발행
     eventPublisher.publishEvent(new CommentCreatedEvent(comment));
+
+    eventPublisher.publishEvent(new PortfolioScoreEvent(portfolioId, PortfolioScoreType.COMMENT));
 
     return CommentResponseDto.of(comment, user.getUsername());
   }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/config/RedisConfig.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.gitprism.GitPRism.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+    return new LettuceConnectionFactory(config);
+  }
+
+  @Bean
+  public StringRedisTemplate stringRedisTemplate() {
+    return new StringRedisTemplate(redisConnectionFactory());
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/config/RedisTestService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/config/RedisTestService.java
@@ -1,0 +1,33 @@
+package com.gitprism.GitPRism.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTestService {
+
+  private final StringRedisTemplate redisTemplate;
+  private final Environment env;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void testRedis() {
+    try {
+      String redisHost = env.getProperty("spring.redis.host");
+      String redisPort = env.getProperty("spring.redis.port");
+      System.out.println("📍 현재 Redis 호스트: " + redisHost);
+      System.out.println("📍 현재 Redis 포트: " + redisPort);
+
+      redisTemplate.opsForValue().set("test", "ok");
+      String value = redisTemplate.opsForValue().get("test");
+      System.out.println("✅ Redis 연결 성공: " + value);
+    } catch (Exception e) {
+      System.out.println("❌ Redis 연결 실패: " + e.getMessage());
+      e.printStackTrace();
+    }
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/likes/service/LikeService.java
@@ -8,6 +8,8 @@ import com.gitprism.GitPRism.github_users.repository.GitHubUserRepository;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
 import com.gitprism.GitPRism.likes.dto.LikeCountResponse;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreEvent;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreType;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -53,6 +55,8 @@ public class LikeService {
     // 🔔 알림 전송
     eventPublisher.publishEvent(new LikeCreatedEvent(like));
 
+    // 포트폴리오 점수 이벤트 발행 (인기 정렬 반영)
+    eventPublisher.publishEvent(new PortfolioScoreEvent(portfolioId, PortfolioScoreType.LIKE));
     return Map.of(
         "message", "좋아요가 추가되었습니다.",
         "code", 201,

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioRankingController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioRankingController.java
@@ -1,0 +1,24 @@
+package com.gitprism.GitPRism.portfolios.controller;
+
+import com.gitprism.GitPRism.portfolios.service.PortfolioRankingService;
+import com.gitprism.GitPRism.portfolios.dto.response.PopularPortfolioResponse;
+import com.gitprism.GitPRism.portfolios.dto.response.PopularPortfolioResponse.PopularPortfolioDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/portfolios")
+public class PortfolioRankingController {
+
+  private final PortfolioRankingService portfolioRankingService;
+
+  @GetMapping("/popular")
+  public ResponseEntity<PopularPortfolioResponse> getPopularPortfolios(
+      @RequestParam(defaultValue = "10") int limit
+  ) {
+    PopularPortfolioResponse response = portfolioRankingService.getPopularPortfolios(limit);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PopularPortfolioResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PopularPortfolioResponse.java
@@ -1,0 +1,27 @@
+package com.gitprism.GitPRism.portfolios.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PopularPortfolioResponse {
+  private String message;
+  private int code;
+  private int count;
+  private List<PopularPortfolioDto> data;
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class PopularPortfolioDto {
+    private Long portfolioId;
+    private String title;
+    private String author;
+    private Double score;
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/listener/PortfolioScoreEventListener.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/listener/PortfolioScoreEventListener.java
@@ -1,0 +1,38 @@
+package com.gitprism.GitPRism.portfolios.listener;
+
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreEvent;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PortfolioScoreEventListener {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private static final String POPULAR_KEY = "popular_portfolios";
+
+  @Async
+  @EventListener
+  public void handleScoreEvent(PortfolioScoreEvent event) {
+    double score = getScoreByType(event.getType());
+    String member = String.valueOf(event.getPortfolioId());
+
+    redisTemplate.opsForZSet().incrementScore(POPULAR_KEY, member, score);
+    log.info("🔥 Redis 점수 업데이트 → {} (+{})", member, score);
+  }
+
+  private double getScoreByType(PortfolioScoreType type) {
+    return switch (type) {
+      case COMMENT -> 1.0;
+      case LIKE -> 2.0;
+      case BOOKMARK -> 3.0;
+      case VIEW -> 0.5;
+    };
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/repository/PortfolioRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/repository/PortfolioRepository.java
@@ -2,6 +2,9 @@ package com.gitprism.GitPRism.portfolios.repository;
 
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+  // 인기 포트폴리오 id 목록 기반으로 실제 포트폴리오 데이터 조회
+  List<Portfolio> findByIdIn(List<Long> ids);
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/score/PortfolioScoreEvent.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/score/PortfolioScoreEvent.java
@@ -1,0 +1,11 @@
+package com.gitprism.GitPRism.portfolios.score;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PortfolioScoreEvent {
+  private final Long portfolioId;
+  private final PortfolioScoreType type;
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/score/PortfolioScoreType.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/score/PortfolioScoreType.java
@@ -1,0 +1,5 @@
+package com.gitprism.GitPRism.portfolios.score;
+
+public enum PortfolioScoreType {
+  COMMENT, LIKE, BOOKMARK, VIEW
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioRankingService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioRankingService.java
@@ -1,0 +1,57 @@
+package com.gitprism.GitPRism.portfolios.service;
+
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
+import com.gitprism.GitPRism.portfolios.dto.response.PopularPortfolioResponse;
+import com.gitprism.GitPRism.portfolios.dto.response.PopularPortfolioResponse.PopularPortfolioDto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioRankingService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final PortfolioRepository portfolioRepository;
+
+  public PopularPortfolioResponse getPopularPortfolios(int limit) {
+    String redisKey = "popular_portfolios";
+    Set<ZSetOperations.TypedTuple<String>> ranking = redisTemplate.opsForZSet()
+        .reverseRangeWithScores(redisKey, 0, limit - 1);
+
+    if (ranking == null || ranking.isEmpty()) {
+      return new PopularPortfolioResponse("인기 포트폴리오 없음", 200, 0, List.of());
+    }
+
+    List<Long> portfolioIds = ranking.stream()
+        .map(tuple -> Long.parseLong(tuple.getValue()))
+        .collect(Collectors.toList());
+
+    Map<Long, Double> scoreMap = ranking.stream()
+        .collect(Collectors.toMap(
+            tuple -> Long.parseLong(tuple.getValue()),
+            ZSetOperations.TypedTuple::getScore
+        ));
+
+    List<Portfolio> portfolios = portfolioRepository.findByIdIn(portfolioIds);
+
+    Map<Long, Portfolio> portfolioMap = portfolios.stream()
+        .collect(Collectors.toMap(Portfolio::getId, p -> p));
+
+    List<PopularPortfolioDto> result = portfolioIds.stream()
+        .map(id -> {
+          Portfolio p = portfolioMap.get(id);
+          return new PopularPortfolioDto(p.getId(), p.getTitle(), p.getUser().getUsername(), scoreMap.get(id));
+        })
+        .collect(Collectors.toList());
+
+
+    return new PopularPortfolioResponse("인기 포트폴리오 조회 성공", 200, result.size(), result);
+  }
+}

--- a/GitPRism/src/test/java/com/gitprism/GitPRism/portfolios/listener/PortfolioScoreEventListenerTest.java
+++ b/GitPRism/src/test/java/com/gitprism/GitPRism/portfolios/listener/PortfolioScoreEventListenerTest.java
@@ -1,0 +1,54 @@
+package com.gitprism.GitPRism.portfolios.listener;
+
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreEvent;
+import com.gitprism.GitPRism.portfolios.score.PortfolioScoreType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import static org.mockito.Mockito.*;
+
+class PortfolioScoreEventListenerTest {
+
+  private RedisTemplate<String, String> redisTemplate;
+  private ZSetOperations<String, String> zSetOperations;
+  private PortfolioScoreEventListener listener;
+
+  @BeforeEach
+  void setUp() {
+    redisTemplate = mock(RedisTemplate.class);
+    zSetOperations = mock(ZSetOperations.class);
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+
+    listener = new PortfolioScoreEventListener(redisTemplate);
+  }
+
+  @Test
+  void testHandleScoreEvent_forLike() {
+    // given
+    Long portfolioId = 1L;
+    PortfolioScoreEvent event = new PortfolioScoreEvent(portfolioId, PortfolioScoreType.LIKE);
+
+    // when
+    listener.handleScoreEvent(event);
+
+    // then
+    verify(zSetOperations, times(1)).incrementScore(
+        "popular_portfolios", "portfolio:1", 2.0
+    );
+  }
+
+  @Test
+  void testHandleScoreEvent_forBookmark() {
+    Long portfolioId = 5L;
+    PortfolioScoreEvent event = new PortfolioScoreEvent(portfolioId, PortfolioScoreType.BOOKMARK);
+
+    listener.handleScoreEvent(event);
+
+    verify(zSetOperations, times(1)).incrementScore(
+        "popular_portfolios", "portfolio:5", 3.0
+    );
+  }
+}


### PR DESCRIPTION
## 🔥 PR 개요
인기 포트폴리오 기능 구현 (Redis Zset기반 점수 누적 및 조회)

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [x] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
- 좋아요, 댓글, 북마크, 조회수 이벤트 발생 시 포트폴리오에 점수를 부여
- 이벤트 발생 → PortfolioScoreEvent 발행
- @Async @EventListener 기반의 PortfolioScoreEventListener가 Redis ZSet에 점수 누적
- Redis Key: "popular_portfolios"
- ZSet Member: 포트폴리오 ID ("1", "2" 등 문자열 형태)
- 점수 기준:
댓글: +1.0
좋아요: +2.0
북마크: +3.0
(조회수는 포트폴리오 기능이 완성되는 대로 추가 예정)

## 고민했던 점 
1. Kafka 대신 Redis를 선택한 이유
- 복잡한 메시지 브로커 인프라 도입 없이도 실시간 반영 가능
Kafka는 안정성과 확장성에 강점이 있지만, 설정/운영 비용이 상대적으로 큼
실시간 점수 누적이라는 단일 목적에 대해 Redis ZSet만으로도 충분히 해결 가능하다고 판단

- 단순 이벤트 기반 처리 + Redis ZSet의 정렬 기능 활용
Kafka처럼 이벤트 큐를 따로 저장하지 않아도 Redis가 바로 정렬된 점수 데이터 제공
Redis는 In-Memory 기반으로 즉시 응답 가능한 실시간 데이터 제공에 적합

- 구현 복잡도 대비 유지보수성과 성능 고려
Kafka 도입 시 Producer/Consumer 설정, Topic 관리, 장애 대응이 필요
반면 Redis 기반 방식은 Spring의 @EventListener, RedisTemplate을 활용해 구조가 단순하고 가시적

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/605a48da-53dc-4f84-b922-a972216b57e0)
![image](https://github.com/user-attachments/assets/1f363763-7f43-472e-92b1-825151540c33)
![image](https://github.com/user-attachments/assets/279ef4d7-59bd-4af7-9d13-80152dc59aa2)

[포트폴리오 순위 조회]
![image](https://github.com/user-attachments/assets/0bdf685c-cb79-4970-963d-61275d8e23cc)

## 🏷️ 관련 이슈
#37 

