### PR TITLE
bug: mysql 한글 깨짐 오류 해결

### DIFF
--- a/GitPRism/GitPRism/mysql/conf.d/my.cnf
+++ b/GitPRism/GitPRism/mysql/conf.d/my.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+default_authentication_plugin = mysql_native_password
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4

--- a/GitPRism/docker-compose.yml
+++ b/GitPRism/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: mysql:8.0
     container_name: mysql-db
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
@@ -14,6 +13,7 @@ services:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
+      - ./GitPRism/mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
     networks:
       - gitprism-network
     restart: always

--- a/GitPRism/mysql/conf.d/my.cnf
+++ b/GitPRism/mysql/conf.d/my.cnf
@@ -1,0 +1,10 @@
+[mysqld]
+default_authentication_plugin = mysql_native_password
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4


### PR DESCRIPTION
## 🔥 PR 개요
mysql 한글 깨짐 오류 해결

## 🎯 변경 사항
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## ✅ 문제 요약
- 처음엔 다음과 같은 문제가 있었지:
- 한글 데이터를 직접 입력해도 빈 칸으로 들어갔고,
- SHOW VARIABLES LIKE 'character_set_%' 해보면 일부 값이 latin1으로 되어 있었어.
- Docker로 올린 my.cnf 설정이 무시되고 있었음 (World-writable config file '/etc/mysql/conf.d/my.cnf' is ignored. 경고).

## 🧩 해결 과정 요약
1. my.cnf 파일 작성하여 docker에 마이그레이션함
```
[mysqld]
 default_authentication_plugin = mysql_native_password
 character-set-server = utf8mb4
 collation-server = utf8mb4_unicode_ci

 [client]
 default-character-set = utf8mb4

 [mysql]
 default-character-set = utf8mb4

```
## 📷 스크린샷 (성공)
![image](https://github.com/user-attachments/assets/068c6c80-6f70-4450-b64b-92a1a0c2e0d7)
![image](https://github.com/user-attachments/assets/a3329f40-68da-44f9-b39f-69c47467865f)

## 🏷️ 관련 이슈
#43 

