### PR TITLE
feat: 포트폴리오 조회 기능 구현

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
@@ -12,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/portfolios")
 @RequiredArgsConstructor
@@ -52,5 +54,14 @@ public class PortfolioController {
 
         PrSummaryResponse response = prSummaryService.summarizeRepository(userId, repoId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 포트폴리오 목록 조회", description = "로그인한 사용자의 포트폴리오를 조회합니다.")
+    public ResponseEntity<List<PortfolioResponse>> getMyPortfolios(Authentication authentication) {
+        String githubId = authentication.getName();
+        GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
+        List<PortfolioResponse> portfolios = portfolioService.getPortfoliosByUser(user.getId());
+        return ResponseEntity.ok(portfolios);
     }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/repository/PortfolioRepository.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/repository/PortfolioRepository.java
@@ -3,8 +3,10 @@ package com.gitprism.GitPRism.portfolios.repository;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
   // 인기 포트폴리오 id 목록 기반으로 실제 포트폴리오 데이터 조회
   List<Portfolio> findByIdIn(List<Long> ids);
+  List<Portfolio> findByUserAndIsDeletedFalse(GitHubUser user);
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -2,7 +2,6 @@ package com.gitprism.GitPRism.portfolios.service;
 
 import com.gitprism.GitPRism.github_users.dto.response.GitHubUserResponseDto;
 import com.gitprism.GitPRism.github_users.service.GitHubUserService;
-import com.gitprism.GitPRism.gitpullrequests.repository.PullRequestRepository;
 import com.gitprism.GitPRism.gitrepositorys.entity.Repo;
 import com.gitprism.GitPRism.gitrepositorys.repository.RepoRepository;
 import com.gitprism.GitPRism.portfolios.dto.response.PortfolioResponse;
@@ -16,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -25,7 +25,6 @@ public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
     private final GitHubUserService gitHubUserService;
     private final RepoRepository repoRepository;
-    private final PullRequestRepository pullRequestRepository;
     private final GitHubApiService gitHubApiService;
     private final OpenAiService openAiService;
 
@@ -109,5 +108,23 @@ public class PortfolioService {
                 .id(portfolio.getId())
                 .data(gptResult)
                 .build();
+    }
+
+    public List<PortfolioResponse> getPortfoliosByUser(Long userId) {
+        com.gitprism.GitPRism.github_users.entity.GitHubUser user = gitHubUserService.findEntityById(userId);
+        List<Portfolio> portfolioList = portfolioRepository.findByUserAndIsDeletedFalse(user);
+
+        return portfolioList.stream()
+                .map(portfolio -> PortfolioResponse.builder()
+                        .id(portfolio.getId())
+                        .message("조회 성공")
+                        .code(200)
+                        .data(Map.of(
+                                "title", portfolio.getTitle(),
+                                "description", portfolio.getDescription(),
+                                "status", portfolio.getStatus().name()
+                        ))
+                        .build()
+                ).toList();
     }
 }

--- a/GitPRism/src/main/resources/db/migration/V11__rename_repo_table_and_add_github_repo_id.sql
+++ b/GitPRism/src/main/resources/db/migration/V11__rename_repo_table_and_add_github_repo_id.sql
@@ -1,0 +1,38 @@
+-- ✅ github_repo_id 컬럼 추가 (조건부)
+SET @col := (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_NAME = 'repos'
+    AND COLUMN_NAME = 'github_repo_id'
+    AND TABLE_SCHEMA = DATABASE()
+);
+
+SET @sql := IF(@col = 0,
+  'ALTER TABLE repos ADD COLUMN github_repo_id BIGINT;',
+  'SELECT "github_repo_id already exists";'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ✅ visibility 컬럼 무조건 추가 (조건문 제거)
+ALTER TABLE repos ADD COLUMN visibility VARCHAR(50) DEFAULT 'public';
+
+-- ✅ 고유 인덱스 추가 (조건부)
+SET @idx := (
+  SELECT COUNT(*)
+  FROM information_schema.STATISTICS
+  WHERE TABLE_NAME = 'repos'
+    AND INDEX_NAME = 'idx_github_repo_id_unique'
+    AND TABLE_SCHEMA = DATABASE()
+);
+
+SET @sql3 := IF(@idx = 0,
+  'CREATE UNIQUE INDEX idx_github_repo_id_unique ON repos(github_repo_id);',
+  'SELECT "Index already exists";'
+);
+
+PREPARE stmt3 FROM @sql3;
+EXECUTE stmt3;
+DEALLOCATE PREPARE stmt3;

--- a/GitPRism/src/main/resources/db/migration/V3__add_column_to_github_repos.sql
+++ b/GitPRism/src/main/resources/db/migration/V3__add_column_to_github_repos.sql
@@ -1,4 +1,4 @@
-CREATE TABLE repos (
+CREATE TABLE repo (
                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
                       git_id VARCHAR(255),
                       repo_name VARCHAR(255),

--- a/GitPRism/src/main/resources/db/migration/V4__add_github_id_to_repo.sql
+++ b/GitPRism/src/main/resources/db/migration/V4__add_github_id_to_repo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repo ADD COLUMN github_id VARCHAR(255);

--- a/GitPRism/src/main/resources/db/migration/V4__add_github_id_to_repos.sql
+++ b/GitPRism/src/main/resources/db/migration/V4__add_github_id_to_repos.sql
@@ -1,1 +1,0 @@
-ALTER TABLE repos ADD COLUMN github_id VARCHAR(255);


### PR DESCRIPTION
feat: 포트폴리오 조회 기능 구현 + repos 테이블 컬럼 추가, 이름 변경

## 🔥 PR 개요
로그인한 사용자의 포트폴리오 조회, repos 테이블의 github의 레포지토리 id와 visibility 추가

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [v] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
1. 로그인한 유저가 조회 요청
![{FDDB2DAA-36FE-4A99-B61E-0D4A271DFF53}](https://github.com/user-attachments/assets/10c7574e-952d-42b9-a87c-e2ba515c615b)
2.  성공화면 
![{F5991B3B-4F61-4B5D-8E85-A64A3CF2535F}](https://github.com/user-attachments/assets/fd037525-458a-4a90-97be-a4d50493bb8a)

+repos 테이블 컬럼 추가
![{9C11AC83-C0B0-4440-9A97-2F273CAE2B92}](https://github.com/user-attachments/assets/ac7dfc99-2752-4993-90b7-157e2d87d271)


## ✅ 테스트 방법
수정된 코드가 잘 작동하는지 테스트하는 방법을 설명해주세요.
- [ ] 유닛 테스트 실행 (`yarn test` 또는 `./gradlew test`)
- [ ] 직접 실행 후 UI 확인
- [v] swagger으로 API 테스트

## 🏷️ 관련 이슈
refactor/#39
feat/#33

## 🚀 추가 정보
리뷰어가 참고하면 좋을 추가적인 정보를 입력해주세요.
