### PR TITLE
#53: refactor:  포트폴리오 다중 입력을 위한 구조 변경

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
@@ -1,9 +1,7 @@
 package com.gitprism.GitPRism.portfolios.controller;
 
-import com.gitprism.GitPRism.portfolios.dto.response.PortfolioResponse;
-import com.gitprism.GitPRism.portfolios.dto.response.PrSummaryResponse;
-import com.gitprism.GitPRism.portfolios.dto.response.PortfolioDetailResponse;
-import com.gitprism.GitPRism.portfolios.dto.response.PublicPortfolioResponse;
+import com.gitprism.GitPRism.portfolios.dto.request.PortfolioBatchRequest;
+import com.gitprism.GitPRism.portfolios.dto.response.*;
 import com.gitprism.GitPRism.portfolios.service.PortfolioService;
 import com.gitprism.GitPRism.portfolios.service.PrSummaryService;
 import com.gitprism.GitPRism.github_users.dto.response.GitHubUserResponseDto;
@@ -27,10 +25,7 @@ public class PortfolioController {
     private final PrSummaryService prSummaryService;
     private final com.gitprism.GitPRism.github_users.service.GitHubUserService gitHubUserService;
 
-    @Operation(
-            summary = "포트폴리오 생성",
-            description = "레포지토리의 PR 분석을 바탕으로 포트폴리오를 생성합니다. 병합된 PR만 분석 대상이 됩니다."
-    )
+    @Operation(summary = "포트폴리오 생성", description = "레포지토리의 PR 분석을 바탕으로 포트폴리오를 생성합니다. 병합된 PR만 분석 대상이 됩니다.")
     @PostMapping
     public ResponseEntity<PortfolioResponse> createPortfolio(
             @RequestParam("repoId") Long repoId,
@@ -42,49 +37,55 @@ public class PortfolioController {
         return ResponseEntity.status(response.getCode()).body(response);
     }
 
-    @Operation(summary = "PR 분석 요약 리스트 생성 + 조회", description = "레포 ID를 기반으로 사용자가 만든 PR을 분석해 포트폴리오 요약 데이터를 반환합니다.")
-    @PostMapping("/summaries")
-    public ResponseEntity<PrSummaryResponse> getPrSummary(
-            @RequestParam Long repoId,
+    @Operation(summary = "다중 레포 기반 포트폴리오 생성")
+    @PostMapping("/batch")
+    public ResponseEntity<PortfolioBatchResponse> createBatchPortfolios(
+            @RequestBody PortfolioBatchRequest request,
             Authentication authentication
     ) {
         String githubId = authentication.getName();
         GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
-        Long userId = user.getId();
+        List<PortfolioDetailDto> created = portfolioService.createBatch(user.getId(), request.getRepoIds());
 
-        PrSummaryResponse response = prSummaryService.summarizeRepository(userId, repoId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(201).body(
+                new PortfolioBatchResponse("포트폴리오 %d개 생성 완료".formatted(created.size()), 201, created.size(), created)
+        );
     }
 
     @GetMapping("/me")
     @Operation(summary = "내 포트폴리오 목록 조회", description = "로그인한 사용자의 포트폴리오를 조회합니다.")
-    public ResponseEntity<List<PortfolioResponse>> getMyPortfolios(Authentication authentication) {
+    public ResponseEntity<List<PortfolioDetailDto>> getMyPortfolios(Authentication authentication) {
         String githubId = authentication.getName();
 
-        // mock 로그인일 경우: user_id = 1 고정
         if (githubId.equals("mock") || githubId.equals("12345678")) {
             return ResponseEntity.ok(portfolioService.getPortfoliosByUser(1L));
         }
 
-        // 일반 사용자 흐름
         GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
-        List<PortfolioResponse> portfolios = portfolioService.getPortfoliosByUser(user.getId());
+        List<PortfolioDetailDto> portfolios = portfolioService.getPortfoliosByUser(user.getId());
         return ResponseEntity.ok(portfolios);
     }
 
-    @Operation(summary = "포트폴리오 상세 조회", description = "포트폴리오 ID를 통해 제목, 설명, 수정일자를 조회합니다.")
+    @Operation(summary = "포트폴리오 상세 조회", description = "포트폴리오 ID를 통해 제목, 설명, 수정일자, 좋아요/댓글/북마크 수를 조회합니다.")
     @GetMapping("/{portfolioId}")
     public ResponseEntity<PortfolioDetailResponse> getPortfolioDetail(
             @PathVariable Long portfolioId,
             Authentication authentication
     ) {
         String githubId = authentication.getName();
-        gitHubUserService.findByGithubId(githubId); // 유저 인증 확인용 (사용 안 해도 문제 없음)
+        gitHubUserService.findByGithubId(githubId); // 인증 확인용 호출
         PortfolioDetailResponse response = portfolioService.getPortfolioDetail(portfolioId);
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "포트폴리오 상태 토글", description = "포트폴리오 상태를 draft와 publish로 전환합니다.")
+    @Operation(summary = "전체 공개 포트폴리오 목록 조회", description = "PUBLISHED 상태의 포트폴리오 전체를 반환합니다.")
+    @GetMapping("/public")
+    public ResponseEntity<Map<String, List<PortfolioDetailDto>>> getAllPublicPortfolios() {
+        List<PortfolioDetailDto> data = portfolioService.getAllPublicPortfolios();
+        return ResponseEntity.ok(Map.of("data", data));
+    }
+
+    @Operation(summary = "포트폴리오 게시 상태 토글", description = "포트폴리오 상태를 PUBLISHED ↔ DRAFT 로 변경합니다.")
     @PutMapping("/{portfolioId}")
     public ResponseEntity<PortfolioResponse> togglePortfolioStatus(
             @PathVariable Long portfolioId,
@@ -96,10 +97,4 @@ public class PortfolioController {
         return ResponseEntity.status(response.getCode()).body(response);
     }
 
-    @Operation(summary = "전체 공개 포트폴리오 목록 조회", description = "PUBLISHED 상태의 포트폴리오 전체를 반환합니다.")
-    @GetMapping("/public")
-    public ResponseEntity<Map<String, List<PublicPortfolioResponse>>> getAllPublicPortfolios() {
-        List<PublicPortfolioResponse> data = portfolioService.getAllPublicPortfolios();
-        return ResponseEntity.ok(Map.of("data", data));
-    }
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/request/PortfolioBatchRequest.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/request/PortfolioBatchRequest.java
@@ -1,0 +1,9 @@
+package com.gitprism.GitPRism.portfolios.dto.request;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class PortfolioBatchRequest {
+    private List<Long> repoIds;
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
@@ -1,0 +1,16 @@
+package com.gitprism.GitPRism.portfolios.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PortfolioBatchResponse {
+    private String message;
+    private int code;
+    private int count;
+    private List<PortfolioDetailDto> data;
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
@@ -14,10 +14,6 @@ public class PortfolioDetailDto {
     private String repoUrl;
     private String title;
     private String description;
-    private int viewCount;
-    private int likeCount;
-    private int bookmarkCount;
-    private int contentCount;
     private String status;
     private LocalDateTime createdAt;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
@@ -4,11 +4,11 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Builder
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class PortfolioDetailResponse {
     private Long portfolioId;
     private String username;

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/entity/Portfolio.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/entity/Portfolio.java
@@ -1,5 +1,6 @@
 package com.gitprism.GitPRism.portfolios.entity;
 
+import com.gitprism.GitPRism.gitrepositorys.entity.Repo;
 import jakarta.persistence.*;
 import lombok.*;
 import com.gitprism.GitPRism.github_users.entity.GitHubUser;
@@ -39,4 +40,7 @@ public class Portfolio {
   public enum Status {
     DRAFT, PUBLISHED
   }
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "repo_id")
+  private Repo repo;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -3,6 +3,7 @@ package com.gitprism.GitPRism.portfolios.service;
 import com.gitprism.GitPRism.bookmarks.repository.BookmarkRepository;
 import com.gitprism.GitPRism.comments.repository.CommentRepository;
 import com.gitprism.GitPRism.github_users.dto.response.GitHubUserResponseDto;
+import com.gitprism.GitPRism.github_users.entity.GitHubUser;
 import com.gitprism.GitPRism.github_users.service.GitHubUserService;
 import com.gitprism.GitPRism.gitrepositorys.entity.Repo;
 import com.gitprism.GitPRism.gitrepositorys.repository.RepoRepository;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -36,32 +38,21 @@ public class PortfolioService {
     public PortfolioResponse createPortfolio(Long userId, Long repoId) {
         GitHubUserResponseDto userDto = gitHubUserService.findById(userId);
         String accessToken = userDto.getAccessToken();
-        String username = userDto.getUsername();
-
         Repo repo = repoRepository.findById(repoId)
                 .orElseThrow(() -> new IllegalArgumentException("레포를 찾을 수 없습니다."));
 
         var userPrs = gitHubApiService.getUserPrsFromRepo(repo, accessToken);
-
-        List<PrSummary> summaries = userPrs.stream()
+        var summaries = userPrs.stream()
                 .map(pr -> {
                     String diff = gitHubApiService.getPrDiff(repo, pr.getNumber(), accessToken);
                     return openAiService.summarizePr(pr.getTitle(), pr.getBody(), diff);
-                })
-                .toList();
-        log.info(" 총 {}개의 PR을 분석했습니다", summaries.size());
-        for (int i = 0; i < summaries.size(); i++) {
-            var s = summaries.get(i);
-            log.info(" PR #{} 요약: {}", i + 1, s.getSummary());
-            log.info("   ┗ 중요 코드: {}", s.getImportantCode());
-        }
+                }).toList();
 
         StringBuilder stackList = new StringBuilder();
         StringBuilder formattedSummaries = new StringBuilder();
 
         for (PrSummary s : summaries) {
             stackList.append(s.getImportantCode()).append("\n");
-
             formattedSummaries.append("""
                     PR 제목: %s
                     PR 내용: %s
@@ -80,16 +71,13 @@ public class PortfolioService {
                 stackList.toString(),
                 formattedSummaries.toString()
         );
-        log.info("GPT에 보낼 포트폴리오 생성 프롬프트:\n{}", prompt);
 
         var gptResult = openAiService.generatePortfolioDescription(prompt);
-        com.gitprism.GitPRism.github_users.entity.GitHubUser user = gitHubUserService.findEntityById(userId);
-        log.info(" GPT 응답 결과: {}", gptResult);
-        log.info("포트폴리오 저장 내용 → title: {}, status: {}",
-                gptResult.get("title"), gptResult.get("status"));
+        GitHubUser user = gitHubUserService.findEntityById(userId);
 
         Portfolio portfolio = Portfolio.builder()
                 .user(user)
+                .repo(repo)
                 .title(gptResult.get("title"))
                 .description(gptResult.get("description"))
                 .status(Status.valueOf(gptResult.get("status").toUpperCase()))
@@ -100,13 +88,11 @@ public class PortfolioService {
         portfolioRepository.save(portfolio);
 
         PortfolioDetailDto detail = PortfolioDetailDto.builder()
+                .repoName(repo.getRepoName())
+                .repoUrl(repo.getUrl())
                 .title(portfolio.getTitle())
                 .description(portfolio.getDescription())
                 .status(portfolio.getStatus().name().toLowerCase())
-                .viewCount(0)
-                .likeCount(0)
-                .bookmarkCount(0)
-                .contentCount(0)
                 .createdAt(portfolio.getCreatedAt())
                 .build();
 
@@ -118,44 +104,36 @@ public class PortfolioService {
                 .build();
     }
 
-    public List<PortfolioResponse> getPortfoliosByUser(Long userId) {
-        com.gitprism.GitPRism.github_users.entity.GitHubUser user = gitHubUserService.findEntityById(userId);
-        List<Portfolio> portfolioList = portfolioRepository.findByUserAndIsDeletedFalse(user);
+    public List<PortfolioDetailDto> createBatch(Long userId, List<Long> repoIds) {
+        List<PortfolioDetailDto> results = new ArrayList<>();
 
-        return portfolioList.stream()
-                .map(portfolio -> {
-                    PortfolioDetailDto detail = PortfolioDetailDto.builder()
-                            .title(portfolio.getTitle())
-                            .description(portfolio.getDescription())
-                            .status(portfolio.getStatus().name().toLowerCase())
-                            .viewCount(0)
-                            .likeCount(0)
-                            .bookmarkCount(0)
-                            .contentCount(0)
-                            .createdAt(portfolio.getCreatedAt())
-                            .build();
+        for (Long repoId : repoIds) {
+            try {
+                PortfolioResponse created = createPortfolio(userId, repoId);
+                results.add(created.getData());
+            } catch (Exception e) {
+                log.warn("레포 {} 처리 중 오류 발생: {}", repoId, e.getMessage());
+            }
+        }
 
-                    return PortfolioResponse.builder()
-                            .id(portfolio.getId())
-                            .message("조회 성공")
-                            .code(200)
-                            .data(detail)
-                            .build();
-                })
-                .toList();
+        // 자동으로 묶음 포트폴리오 저장
+        createCombinedPortfolio(userId, repoIds);
+
+        return results;
     }
+
 
     public PortfolioDetailResponse getPortfolioDetail(Long portfolioId) {
         Portfolio portfolio = portfolioRepository.findByIdAndIsDeletedFalse(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 포트폴리오가 존재하지 않습니다."));
 
-        if (!portfolio.getStatus().equals(Portfolio.Status.PUBLISHED)) {
+        if (!portfolio.getStatus().equals(Status.PUBLISHED)) {
             throw new IllegalStateException("해당 포트폴리오는 아직 공개되지 않았습니다.");
         }
 
         int likeCount = likeRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
         int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
-        int contentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId); // 댓글 수
+        int contentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
 
         return PortfolioDetailResponse.builder()
                 .portfolioId(portfolio.getId())
@@ -169,7 +147,37 @@ public class PortfolioService {
                 .build();
     }
 
-    @Transactional
+    public List<PortfolioDetailDto> getPortfoliosByUser(Long userId) {
+        GitHubUser user = gitHubUserService.findEntityById(userId);
+        List<Portfolio> portfolios = portfolioRepository.findByUserAndIsDeletedFalse(user);
+
+        return portfolios.stream()
+                .map(p -> PortfolioDetailDto.builder()
+                        .repoName(p.getRepo() != null ? p.getRepo().getRepoName() : null)
+                        .repoUrl(p.getRepo() != null ? p.getRepo().getUrl() : null)
+                        .title(p.getTitle())
+                        .description(p.getDescription())
+                        .status(p.getStatus().name().toLowerCase())
+                        .createdAt(p.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    public List<PortfolioDetailDto> getAllPublicPortfolios() {
+        List<Portfolio> published = portfolioRepository.findByStatusAndIsDeletedFalse(Status.PUBLISHED);
+
+        return published.stream()
+                .map(p -> PortfolioDetailDto.builder()
+                        .repoName(p.getRepo() != null ? p.getRepo().getRepoName() : null)
+                        .repoUrl(p.getRepo() != null ? p.getRepo().getUrl() : null)
+                        .title(p.getTitle())
+                        .description(p.getDescription())
+                        .status(p.getStatus().name().toLowerCase())
+                        .createdAt(p.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
     public PortfolioResponse togglePortfolioStatus(Long userId, Long portfolioId) {
         Portfolio portfolio = portfolioRepository.findByIdAndIsDeletedFalse(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));
@@ -185,22 +193,16 @@ public class PortfolioService {
         portfolio.setStatus(newStatus);
         portfolio.setUpdatedAt(LocalDateTime.now());
 
-        int likeCount = likeRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
-        int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
-        int contentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
-
         String message = (newStatus == Portfolio.Status.PUBLISHED)
                 ? "포트폴리오가 성공적으로 게시되었습니다."
                 : "포트폴리오가 임시 저장되었습니다.";
 
         PortfolioDetailDto detail = PortfolioDetailDto.builder()
+                .repoName(portfolio.getRepo() != null ? portfolio.getRepo().getRepoName() : null)
+                .repoUrl(portfolio.getRepo() != null ? portfolio.getRepo().getUrl() : null)
                 .title(portfolio.getTitle())
                 .description(portfolio.getDescription())
                 .status(newStatus.name().toLowerCase())
-                .viewCount(0)
-                .likeCount(likeCount)
-                .bookmarkCount(bookmarkCount)
-                .contentCount(contentCount)
                 .createdAt(portfolio.getCreatedAt())
                 .build();
 
@@ -212,27 +214,49 @@ public class PortfolioService {
                 .build();
     }
 
-    public List<PublicPortfolioResponse> getAllPublicPortfolios() {
-        List<Portfolio> published = portfolioRepository.findByStatusAndIsDeletedFalse(Portfolio.Status.PUBLISHED);
+    public Portfolio createCombinedPortfolio(Long userId, List<Long> repoIds) {
+        GitHubUser user = gitHubUserService.findEntityById(userId);
+        StringBuilder fullDescription = new StringBuilder();
 
-        return published.stream()
-                .map(p -> {
-                    int likeCount = likeRepository.countByPortfolioIdAndIsDeletedFalse(p.getId());
-                    int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(p.getId());
-                    int commentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(p.getId());
+        for (Long repoId : repoIds) {
+            Repo repo = repoRepository.findById(repoId)
+                    .orElseThrow(() -> new IllegalArgumentException("레포를 찾을 수 없습니다."));
+            String accessToken = gitHubUserService.findById(userId).getAccessToken();
+            var prs = gitHubApiService.getUserPrsFromRepo(repo, accessToken);
 
-                    return PublicPortfolioResponse.builder()
-                            .portfolioId(p.getId())
-                            .title(p.getTitle())
-                            .username(p.getUser().getUsername())
-                            .status(p.getStatus().name().toLowerCase())
-                            .updated_at(p.getUpdatedAt())
-                            .likeCount(likeCount)
-                            .bookmarkCount(bookmarkCount)
-                            .commentCount(commentCount)
-                            .build();
-                }).toList();
+            for (var pr : prs) {
+                String diff = gitHubApiService.getPrDiff(repo, pr.getNumber(), accessToken);
+                var summary = openAiService.summarizePr(pr.getTitle(), pr.getBody(), diff);
+
+                // 정제 처리
+                String cleanSummary = summary.getSummary().replace("\n", "\\n").trim();
+                String cleanCode = summary.getImportantCode().replace("\n", "\\n").trim();
+
+                fullDescription.append("""
+                    ▸ Repository: %s
+                    PR 제목: %s
+                    요약: %s
+                    주요 코드: %s
+
+                    """.formatted(
+                        repo.getRepoName(),
+                        pr.getTitle(),
+                        cleanSummary,
+                        cleanCode
+                ));
+            }
+        }
+
+        Portfolio combined = Portfolio.builder()
+                .user(user)
+                .title("요약 포트폴리오 (%d개 레포)".formatted(repoIds.size()))
+                .description(fullDescription.toString())
+                .status(Status.DRAFT)
+                .isDeleted(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return portfolioRepository.save(combined);
     }
-
-
 }

--- a/GitPRism/src/main/resources/db/migration/V13__add_repo_id_to_portfolio.sql
+++ b/GitPRism/src/main/resources/db/migration/V13__add_repo_id_to_portfolio.sql
@@ -1,0 +1,9 @@
+-- 포트폴리오 테이블에 레포 외래 키 컬럼 추가
+ALTER TABLE portfolios
+    ADD COLUMN repo_id BIGINT AFTER user_id;
+
+-- repo_id → repos 테이블의 id 를 참조하는 외래키 제약조건 설정
+ALTER TABLE portfolios
+    ADD CONSTRAINT fk_portfolio_repo
+        FOREIGN KEY (repo_id)
+            REFERENCES repos(id);


### PR DESCRIPTION
## 🔥 PR 개요
개별 생성과 추가적으로 다중 입력을 위해 table에 repo url, id 추가, 다중 생성 api 구현

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ 0 ] 🔧 리팩토링 (Refactor)
- [ 0 ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
request값
![image](https://github.com/user-attachments/assets/8efd0ece-4717-4494-9a72-258b699a793e)
response 값
![image](https://github.com/user-attachments/assets/4db77243-9b5c-431a-a556-c78eee3dd383)
 다중으로 생성한 포트폴리오 리스트도 개별 포트폴리오와 함께 sql에 저장

## ✅ 테스트 방법
수정된 코드가 잘 작동하는지 테스트하는 방법을 설명해주세요.
- [ ] 유닛 테스트 실행 (`yarn test` 또는 `./gradlew test`)
- [ ] 직접 실행 후 UI 확인
- [ 0 ] Swagger으로 API 테스트

## 📷 스크린샷 (선택)
UI 변경이 있다면 스크린샷을 첨부해주세요.

## 🏷️ 관련 이슈
feat/#33

## 🚀 추가 정보
추후 해당 리스트 포트폴리오 id 응답값에 추가
