### PR TITLE
refactor: 다중 레포 기반 포트폴리오 응답값 수정 , 사용자 이미지 추가

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/dto/response/GitHubUserResponseDto.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/dto/response/GitHubUserResponseDto.java
@@ -18,4 +18,5 @@ public class GitHubUserResponseDto {
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
   private Boolean deleted; // ✅ deleted로 정확히 명시!
+  private String avatarUrl;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/dto/response/LoginResponseDto.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/dto/response/LoginResponseDto.java
@@ -11,4 +11,5 @@ public class LoginResponseDto {
   private String githubId;
   private String username;
   private String email;
+  private String avatarUrl;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/entity/GitHubUser.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/entity/GitHubUser.java
@@ -27,6 +27,9 @@ public class GitHubUser {
   private String email;
 
   @Column(length = 1000)
+  private String avatarUrl;
+
+  @Column(length = 1000)
   private String accessToken;
 
   @CreatedDate

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/service/OAuthService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/github-users/service/OAuthService.java
@@ -83,6 +83,7 @@ public class OAuthService {
     String githubId = String.valueOf(userInfo.get("id"));
     String username = (String) userInfo.get("login");
     String email = (String) userInfo.get("email"); // null일 수 있음
+    String avatarUrl = (String) userInfo.get("avatar_url");
 
     // 이미 존재하면 업데이트, 없으면 생성
     GitHubUser user = userRepository.findByGithubId(githubId)
@@ -90,6 +91,7 @@ public class OAuthService {
           existing.setUsername(username);
           existing.setEmail(email);
           existing.setAccessToken(accessToken);
+          existing.setAvatarUrl(avatarUrl);
           return existing;
         })
         .orElse(GitHubUser.builder()
@@ -97,6 +99,7 @@ public class OAuthService {
             .username(username)
             .email(email)
             .accessToken(accessToken)
+            .avatarUrl(avatarUrl)
             .build());
 
     userRepository.save(user);
@@ -109,6 +112,7 @@ public class OAuthService {
         .githubId(user.getGithubId())
         .username(user.getUsername())
         .email(user.getEmail())
+        .avatarUrl(user.getAvatarUrl())
         .id(user.getId())
         .build();
   }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioController.java
@@ -45,11 +45,9 @@ public class PortfolioController {
     ) {
         String githubId = authentication.getName();
         GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
-        List<PortfolioDetailDto> created = portfolioService.createBatch(user.getId(), request.getRepoIds());
 
-        return ResponseEntity.status(201).body(
-                new PortfolioBatchResponse("포트폴리오 %d개 생성 완료".formatted(created.size()), 201, created.size(), created)
-        );
+        PortfolioBatchResponse response = portfolioService.createBatch(user.getId(), request.getRepoIds());
+        return ResponseEntity.status(response.getCode()).body(response);
     }
 
     @GetMapping("/me")
@@ -73,15 +71,19 @@ public class PortfolioController {
             Authentication authentication
     ) {
         String githubId = authentication.getName();
-        gitHubUserService.findByGithubId(githubId); // 인증 확인용 호출
-        PortfolioDetailResponse response = portfolioService.getPortfolioDetail(portfolioId);
+        GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
+        PortfolioDetailResponse response = portfolioService.getPortfolioDetail(portfolioId, user.getId());
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "전체 공개 포트폴리오 목록 조회", description = "PUBLISHED 상태의 포트폴리오 전체를 반환합니다.")
     @GetMapping("/public")
-    public ResponseEntity<Map<String, List<PortfolioDetailDto>>> getAllPublicPortfolios() {
-        List<PortfolioDetailDto> data = portfolioService.getAllPublicPortfolios();
+    public ResponseEntity<Map<String, List<PortfolioDetailDto>>> getAllPublicPortfolios(
+            Authentication authentication
+    ) {
+        String githubId = authentication.getName();
+        GitHubUserResponseDto user = gitHubUserService.findByGithubId(githubId);
+        List<PortfolioDetailDto> data = portfolioService.getAllPublicPortfolios(user.getId());
         return ResponseEntity.ok(Map.of("data", data));
     }
 

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 public class PortfolioBatchResponse {
     private String message;
+    private Long combinedPortfolioId;
     private int code;
     private int count;
     private List<PortfolioDetailDto> data;

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
@@ -10,10 +10,14 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class PortfolioDetailDto {
+    private Long portfolioId;
     private String repoName;
     private String repoUrl;
     private String title;
     private String description;
     private String status;
     private LocalDateTime createdAt;
+    private boolean bookmarked;
+    private String avatarUrl;
+    private String username;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
@@ -18,4 +18,5 @@ public class PortfolioDetailResponse {
     private int likeCount;
     private int bookmarkCount;
     private int contentCount;
+    private boolean bookmarked;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -12,7 +12,6 @@ import com.gitprism.GitPRism.portfolios.dto.response.*;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio.Status;
 import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,7 +57,7 @@ public class PortfolioService {
                     PR 내용: %s
                     요약: %s
                     중요 코드 및 기술: %s
-
+                    
                     """.formatted(
                     s.getPrTitle(),
                     s.getPrBody(),
@@ -104,7 +103,7 @@ public class PortfolioService {
                 .build();
     }
 
-    public List<PortfolioDetailDto> createBatch(Long userId, List<Long> repoIds) {
+    public PortfolioBatchResponse createBatch(Long userId, List<Long> repoIds) {
         List<PortfolioDetailDto> results = new ArrayList<>();
 
         for (Long repoId : repoIds) {
@@ -116,14 +115,19 @@ public class PortfolioService {
             }
         }
 
-        // 자동으로 묶음 포트폴리오 저장
-        createCombinedPortfolio(userId, repoIds);
+        Portfolio combined = createCombinedPortfolio(userId, repoIds);
 
-        return results;
+        return new PortfolioBatchResponse(
+                "포트폴리오 %d개 생성 완료".formatted(results.size()),
+                combined.getId(),
+                201,
+                results.size(),
+                results
+        );
     }
 
 
-    public PortfolioDetailResponse getPortfolioDetail(Long portfolioId) {
+    public PortfolioDetailResponse getPortfolioDetail(Long portfolioId, Long userId) {
         Portfolio portfolio = portfolioRepository.findByIdAndIsDeletedFalse(portfolioId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 포트폴리오가 존재하지 않습니다."));
 
@@ -131,9 +135,11 @@ public class PortfolioService {
             throw new IllegalStateException("해당 포트폴리오는 아직 공개되지 않았습니다.");
         }
 
+        GitHubUser user = gitHubUserService.findEntityById(userId);
         int likeCount = likeRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
         int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
         int contentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
+        boolean bookmarked = bookmarkRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
 
         return PortfolioDetailResponse.builder()
                 .portfolioId(portfolio.getId())
@@ -144,6 +150,7 @@ public class PortfolioService {
                 .likeCount(likeCount)
                 .bookmarkCount(bookmarkCount)
                 .contentCount(contentCount)
+                .bookmarked(bookmarked)
                 .build();
     }
 
@@ -153,6 +160,7 @@ public class PortfolioService {
 
         return portfolios.stream()
                 .map(p -> PortfolioDetailDto.builder()
+                        .portfolioId(p.getId())
                         .repoName(p.getRepo() != null ? p.getRepo().getRepoName() : null)
                         .repoUrl(p.getRepo() != null ? p.getRepo().getUrl() : null)
                         .title(p.getTitle())
@@ -163,18 +171,25 @@ public class PortfolioService {
                 .toList();
     }
 
-    public List<PortfolioDetailDto> getAllPublicPortfolios() {
+    public List<PortfolioDetailDto> getAllPublicPortfolios(Long userId) {
+        GitHubUser user = gitHubUserService.findEntityById(userId);
         List<Portfolio> published = portfolioRepository.findByStatusAndIsDeletedFalse(Status.PUBLISHED);
 
+
         return published.stream()
-                .map(p -> PortfolioDetailDto.builder()
-                        .repoName(p.getRepo() != null ? p.getRepo().getRepoName() : null)
-                        .repoUrl(p.getRepo() != null ? p.getRepo().getUrl() : null)
-                        .title(p.getTitle())
-                        .description(p.getDescription())
-                        .status(p.getStatus().name().toLowerCase())
-                        .createdAt(p.getCreatedAt())
-                        .build())
+                .map(p -> {
+                    boolean bookmarked = bookmarkRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, p);
+                    return PortfolioDetailDto.builder()
+                            .portfolioId(p.getId())
+                            .username(p.getUser().getUsername())
+                            .avatarUrl(p.getUser().getAvatarUrl())
+                            .title(p.getTitle())
+                            .description(p.getDescription())
+                            .status(p.getStatus().name().toLowerCase())
+                            .createdAt(p.getCreatedAt())
+                            .bookmarked(bookmarked)
+                            .build();
+                })
                 .toList();
     }
 
@@ -193,11 +208,14 @@ public class PortfolioService {
         portfolio.setStatus(newStatus);
         portfolio.setUpdatedAt(LocalDateTime.now());
 
+        portfolioRepository.save(portfolio);
+
         String message = (newStatus == Portfolio.Status.PUBLISHED)
                 ? "포트폴리오가 성공적으로 게시되었습니다."
                 : "포트폴리오가 임시 저장되었습니다.";
 
         PortfolioDetailDto detail = PortfolioDetailDto.builder()
+                .portfolioId(portfolio.getId())
                 .repoName(portfolio.getRepo() != null ? portfolio.getRepo().getRepoName() : null)
                 .repoUrl(portfolio.getRepo() != null ? portfolio.getRepo().getUrl() : null)
                 .title(portfolio.getTitle())
@@ -219,31 +237,19 @@ public class PortfolioService {
         StringBuilder fullDescription = new StringBuilder();
 
         for (Long repoId : repoIds) {
-            Repo repo = repoRepository.findById(repoId)
-                    .orElseThrow(() -> new IllegalArgumentException("레포를 찾을 수 없습니다."));
-            String accessToken = gitHubUserService.findById(userId).getAccessToken();
-            var prs = gitHubApiService.getUserPrsFromRepo(repo, accessToken);
+            try {
+                PortfolioResponse pr = createPortfolio(userId, repoId);
+                String title = pr.getData().getTitle();
+                String description = pr.getData().getDescription();
 
-            for (var pr : prs) {
-                String diff = gitHubApiService.getPrDiff(repo, pr.getNumber(), accessToken);
-                var summary = openAiService.summarizePr(pr.getTitle(), pr.getBody(), diff);
-
-                // 정제 처리
-                String cleanSummary = summary.getSummary().replace("\n", "\\n").trim();
-                String cleanCode = summary.getImportantCode().replace("\n", "\\n").trim();
-
+                // 형식: ▸ 제목 \n 설명 \n\n
                 fullDescription.append("""
-                    ▸ Repository: %s
-                    PR 제목: %s
-                    요약: %s
-                    주요 코드: %s
-
-                    """.formatted(
-                        repo.getRepoName(),
-                        pr.getTitle(),
-                        cleanSummary,
-                        cleanCode
-                ));
+                        ▸ %s
+                        %s
+                        
+                        """.formatted(title, description));
+            } catch (Exception e) {
+                log.warn("레포 {} 처리 중 오류 발생: {}", repoId, e.getMessage());
             }
         }
 
@@ -260,3 +266,4 @@ public class PortfolioService {
         return portfolioRepository.save(combined);
     }
 }
+

--- a/GitPRism/src/main/resources/db/migration/V14__add_avatarUrl_to_users_table.sql
+++ b/GitPRism/src/main/resources/db/migration/V14__add_avatarUrl_to_users_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE github_users ADD COLUMN avatar_url VARCHAR(1000);


### PR DESCRIPTION
## 🔥 PR 개요
다중 레포 기반 포트폴리오 id 응답값 추가/내용 수정
사용자 이미지 (avatar_url) 추가
포트폴리오 조회 응답값 수정

## 🎯 변경 사항
- [ 0 ] 🐛 버그 수정 (Bug Fix)
- [ 0 ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
다중 레포 기반 포트폴리오 id 응답값 추가
![{47DB9898-D020-48B1-B0E4-0E8B66D95952}](https://github.com/user-attachments/assets/7c5afcc8-c03d-4748-9471-fe9b7a9daa63)
다중 레포 기반 포트폴리오가 저장되는 내용이 다른 오류 수정
<이전>
![{82727E2E-18DB-4180-BB85-21C2792EF653}](https://github.com/user-attachments/assets/5f1dd0b1-89a0-4248-91cb-fcb8bde01f40)
<이후>
![{6D2633B8-F7E1-4DF3-BA9D-82AAD79A3172}](https://github.com/user-attachments/assets/d342011f-1fae-47dd-8c4b-8d3bf2424a2f)

포트폴리오 상세 조회시 댓글 수 미증가 오류 수정
![{D6D8D6EC-AC82-46DF-9984-0BA6DEA6C309}](https://github.com/user-attachments/assets/eb76020f-2aa1-4af3-ac1d-6cbc3504710b)

로그인시 사용자 이미지 url 추가 (로그인할때마다 업데이트)
![image](https://github.com/user-attachments/assets/96275ec3-6e47-4f54-a680-c8806d8be208)

전체 공개 포트폴리오 목록 조회에서 사용자 이름, 이미지 추가
![{2DE93424-0637-4FF9-B0B2-5C354FC4E64B}](https://github.com/user-attachments/assets/1c99e6e2-2d21-4789-bde0-c2ef5b81d46e)

## ✅ 테스트 방법
수정된 코드가 잘 작동하는지 테스트하는 방법을 설명해주세요.
- [ ] 유닛 테스트 실행 (`yarn test` 또는 `./gradlew test`)
- [ ] 직접 실행 후 UI 확인
- [ 0 ] Swagger으로 API 테스트

## 📷 스크린샷 (선택)
UI 변경이 있다면 스크린샷을 첨부해주세요.

## 🏷️ 관련 이슈
feat/#48

## 🚀 추가 정보
리뷰어가 참고하면 좋을 추가적인 정보를 입력해주세요.
