### PR TITLE
refactor: 전체 리스트 조회 응답값 수정, 다중 레포 기반 포트폴리오 생성 수정

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
@@ -14,4 +14,5 @@ public class PortfolioBatchResponse {
     private int code;
     private int count;
     private List<PortfolioDetailDto> data;
+    private List<String> failures;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailDto.java
@@ -11,13 +11,16 @@ import java.time.LocalDateTime;
 @Builder
 public class PortfolioDetailDto {
     private Long portfolioId;
+    private String username;
+    private String avatarUrl;
     private String repoName;
     private String repoUrl;
     private String title;
     private String description;
+    private int likeCount;
+    private boolean liked;
+    private int bookmarkCount;
+    private boolean bookmarked;
     private String status;
     private LocalDateTime createdAt;
-    private boolean bookmarked;
-    private String avatarUrl;
-    private String username;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioDetailResponse.java
@@ -16,7 +16,8 @@ public class PortfolioDetailResponse {
     private String description;
     private LocalDateTime updatedAt;
     private int likeCount;
+    private boolean liked;
     private int bookmarkCount;
-    private int contentCount;
     private boolean bookmarked;
+    private int contentCount;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -105,24 +105,27 @@ public class PortfolioService {
 
     public PortfolioBatchResponse createBatch(Long userId, List<Long> repoIds) {
         List<PortfolioDetailDto> results = new ArrayList<>();
+        List<String> failures = new ArrayList<>();
 
         for (Long repoId : repoIds) {
             try {
                 PortfolioResponse created = createPortfolio(userId, repoId);
                 results.add(created.getData());
             } catch (Exception e) {
-                log.warn("레포 {} 처리 중 오류 발생: {}", repoId, e.getMessage());
+                log.error("❌ 레포 ID {} 처리 중 오류 발생: {}", repoId, e.getMessage(), e);
+                failures.add("repoId: " + repoId);
             }
         }
 
-        Portfolio combined = createCombinedPortfolio(userId, repoIds);
+        Portfolio combined = createCombinedPortfolio(userId, results);
 
         return new PortfolioBatchResponse(
-                "포트폴리오 %d개 생성 완료".formatted(results.size()),
+                "포트폴리오 %d개 생성, %d개 실패".formatted(results.size(), failures.size()),
                 combined.getId(),
                 201,
                 results.size(),
-                results
+                results,
+                failures
         );
     }
 
@@ -140,6 +143,7 @@ public class PortfolioService {
         int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
         int contentCount = commentRepository.countByPortfolioIdAndIsDeletedFalse(portfolioId);
         boolean bookmarked = bookmarkRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
+        boolean liked = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
 
         return PortfolioDetailResponse.builder()
                 .portfolioId(portfolio.getId())
@@ -151,6 +155,7 @@ public class PortfolioService {
                 .bookmarkCount(bookmarkCount)
                 .contentCount(contentCount)
                 .bookmarked(bookmarked)
+                .liked(liked)
                 .build();
     }
 
@@ -179,6 +184,9 @@ public class PortfolioService {
         return published.stream()
                 .map(p -> {
                     boolean bookmarked = bookmarkRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, p);
+                    boolean liked = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, p);
+                    int likeCount = likeRepository.countByPortfolioIdAndIsDeletedFalse(p.getId());
+                    int bookmarkCount = bookmarkRepository.countByPortfolioIdAndIsDeletedFalse(p.getId());
                     return PortfolioDetailDto.builder()
                             .portfolioId(p.getId())
                             .username(p.getUser().getUsername())
@@ -188,6 +196,9 @@ public class PortfolioService {
                             .status(p.getStatus().name().toLowerCase())
                             .createdAt(p.getCreatedAt())
                             .bookmarked(bookmarked)
+                            .liked(liked)
+                            .likeCount(likeCount)
+                            .bookmarkCount(bookmarkCount)
                             .build();
                 })
                 .toList();
@@ -232,30 +243,21 @@ public class PortfolioService {
                 .build();
     }
 
-    public Portfolio createCombinedPortfolio(Long userId, List<Long> repoIds) {
+    public Portfolio createCombinedPortfolio(Long userId, List<PortfolioDetailDto> singleResults) {
         GitHubUser user = gitHubUserService.findEntityById(userId);
         StringBuilder fullDescription = new StringBuilder();
 
-        for (Long repoId : repoIds) {
-            try {
-                PortfolioResponse pr = createPortfolio(userId, repoId);
-                String title = pr.getData().getTitle();
-                String description = pr.getData().getDescription();
+        for (PortfolioDetailDto dto : singleResults) {
+            fullDescription.append("""
+                ▸ %s
+                %s
 
-                // 형식: ▸ 제목 \n 설명 \n\n
-                fullDescription.append("""
-                        ▸ %s
-                        %s
-                        
-                        """.formatted(title, description));
-            } catch (Exception e) {
-                log.warn("레포 {} 처리 중 오류 발생: {}", repoId, e.getMessage());
-            }
+                """.formatted(dto.getTitle(), dto.getDescription()));
         }
 
         Portfolio combined = Portfolio.builder()
                 .user(user)
-                .title("요약 포트폴리오 (%d개 레포)".formatted(repoIds.size()))
+                .title("요약 포트폴리오 (%d개 레포)".formatted(singleResults.size()))
                 .description(fullDescription.toString())
                 .status(Status.DRAFT)
                 .isDeleted(false)


### PR DESCRIPTION
## 🔥 PR 개요
전체 리스트 조회 응답값(북마크 개수, 좋아요 개수, 좋아요 여부) 추가 , 다중레포 기반 포트폴리오  생성 시 생성 누락이 생기면 조회 가능하게 수정

## 🎯 변경 사항
- [ 0 ] 🐛 버그 수정 (Bug Fix)
- [ 0 ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
1.전체 리스트 조회 응답값 추가
[response 값]
![{4D66C4D0-E4B4-46E8-A2D1-527800844FDC}](https://github.com/user-attachments/assets/143140d1-2c56-489d-ac57-67b14e34d8d1)

2.
다중 레포 기반 포트폴리오 생성 시, 생성 누락이 생기면 조회 가능
[response 값]
![{7D0692E2-184B-43F6-B124-C7F842E345DF}](https://github.com/user-attachments/assets/1796bf7c-0c1b-478d-a16b-2ccd9b897fd1)

## ✅ 테스트 방법
수정된 코드가 잘 작동하는지 테스트하는 방법을 설명해주세요.
- [ ] 유닛 테스트 실행 (`yarn test` 또는 `./gradlew test`)
- [ ] 직접 실행 후 UI 확인
- [ 0 ] Swagger으로 API 테스트

## 📷 스크린샷 (선택)
UI 변경이 있다면 스크린샷을 첨부해주세요.

## 🏷️ 관련 이슈
feat/#48, refactor/#53
## 🚀 추가 정보
리뷰어가 참고하면 좋을 추가적인 정보를 입력해주세요.
