### PR TITLE
feat: feat: Elasticsearch 인덱싱용 PortfolioDocument 도입 및 초기 색인 로직 추가

### DIFF
--- a/GitPRism/build.gradle
+++ b/GitPRism/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'co.elastic.clients:elasticsearch-java:8.11.0'
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 tasks.named('test') {

--- a/GitPRism/docker-compose.yml
+++ b/GitPRism/docker-compose.yml
@@ -43,6 +43,32 @@ services:
       retries: 10
       start_period: 10s
 
+  elasticsearch:
+    build:
+      context: ./elasticsearch
+    container_name: gitprism-elasticsearch
+    environment:
+      - node.name=gitprism-node
+      - cluster.name=gitprism-cluster
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    networks:
+      - gitprism-network
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://gitprism-elasticsearch:9200/_cluster/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
 
   flyway:
     image: flyway/flyway:11.4.0
@@ -74,6 +100,8 @@ services:
         condition: service_completed_successfully
       redis:
         condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -89,6 +117,7 @@ services:
 volumes:
   db_data:
   redis_data:
+  es_data:
 
 networks:
   gitprism-network:

--- a/GitPRism/elasticsearch/Dockerfile
+++ b/GitPRism/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.9.0
+
+# nori 플러그인 설치
+RUN elasticsearch-plugin install analysis-nori --batch

--- a/GitPRism/mapping.json
+++ b/GitPRism/mapping.json
@@ -1,0 +1,37 @@
+{
+  "settings": {
+    "analysis": {
+      "tokenizer": {
+        "nori_tokenizer": {
+          "type": "nori_tokenizer",
+          "decompound_mode": "mixed"
+        }
+      },
+      "filter": {
+        "nori_pos_filter": {
+          "type": "nori_part_of_speech",
+          "stoptags": ["E", "J", "SC", "SE", "SP", "SSO", "SSC", "SF", "SY"]
+        }
+      },
+      "analyzer": {
+        "nori_analyzer": {
+          "type": "custom",
+          "tokenizer": "nori_tokenizer",
+          "filter": ["lowercase", "nori_pos_filter"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "id": { "type": "long" },
+      "title": { "type": "text", "analyzer": "nori_analyzer" },
+      "description": { "type": "text", "analyzer": "nori_analyzer" },
+      "status": { "type": "keyword" },
+      "createdAt": { "type": "date" },
+      "updatedAt": { "type": "date" },
+      "isDeleted": { "type": "boolean" },
+      "repoOrgAvatarUrl": { "type": "text" }
+    }
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/config/ElasticsearchConfig.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/config/ElasticsearchConfig.java
@@ -1,0 +1,34 @@
+package com.gitprism.GitPRism.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+
+  @Bean
+  public ElasticsearchClient elasticsearchClient() {
+    // ✅ 기존 JacksonJsonpMapper 대신 커스텀 ObjectMapper 생성
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule()); // LocalDateTime 직렬화 가능
+
+    JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(mapper);
+
+    RestClient restClient = RestClient.builder(
+        new HttpHost(
+            System.getenv("ELASTICSEARCH_HOST"),
+            Integer.parseInt(System.getenv("ELASTICSEARCH_PORT")),
+            "http"
+        )
+    ).build();
+
+    return new ElasticsearchClient(new RestClientTransport(restClient, jsonpMapper));
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioSearchController.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/controller/PortfolioSearchController.java
@@ -1,0 +1,28 @@
+package com.gitprism.GitPRism.portfolios.controller;
+
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import com.gitprism.GitPRism.portfolios.service.PortfolioSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/portfolios")
+@RequiredArgsConstructor
+@Tag(name = "Portfolio", description = "포트폴리오 검색 API")
+public class PortfolioSearchController {
+
+  private final PortfolioSearchService portfolioSearchService;
+
+  @GetMapping("/search")
+  @Operation(summary = "포트폴리오 검색", description = "포트폴리오 제목 및 설명에서 검색")
+  public ResponseEntity<List<Portfolio>> searchPortfolios(@RequestParam String query) throws IOException {
+    List<Portfolio> portfolios = portfolioSearchService.searchPortfolios(query);
+    return ResponseEntity.ok(portfolios);
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/document/PortfolioDocument.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/document/PortfolioDocument.java
@@ -1,0 +1,23 @@
+package com.gitprism.GitPRism.portfolios.document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PortfolioDocument implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private Long id;
+  private String title;
+  private String description;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioIndexer.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioIndexer.java
@@ -1,0 +1,42 @@
+package com.gitprism.GitPRism.portfolios.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.gitprism.GitPRism.portfolios.document.PortfolioDocument;
+import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PortfolioIndexer {
+
+  private final PortfolioRepository portfolioRepository;
+  private final ElasticsearchClient elasticsearchClient;
+
+  @PostConstruct
+  public void indexPortfolios() {
+    portfolioRepository.findAll().forEach(portfolio -> {
+      try {
+        PortfolioDocument doc = PortfolioDocument.builder()
+            .id(portfolio.getId())
+            .title(portfolio.getTitle())
+            .description(portfolio.getDescription())
+            .createdAt(portfolio.getCreatedAt())
+            .updatedAt(portfolio.getUpdatedAt())
+            .build();
+
+        elasticsearchClient.index(i -> i
+            .index("portfolios")
+            .id(doc.getId().toString())
+            .document(doc)
+        );
+        log.info("✅ Indexed portfolio: {}", doc.getTitle());
+      } catch (Exception e) {
+        log.error("❌ Failed to index portfolio ID {}", portfolio.getId(), e);
+      }
+    });
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioSearchService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioSearchService.java
@@ -1,0 +1,39 @@
+package com.gitprism.GitPRism.portfolios.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioSearchService {
+
+  private final ElasticsearchClient elasticsearchClient;
+
+  public List<Portfolio> searchPortfolios(String query) throws IOException {
+    SearchRequest searchRequest = new SearchRequest.Builder()
+        .index("portfolios")
+        .query(q -> q
+            .multiMatch(m -> m
+                .query(query)
+                .fields("title", "description")
+                .fuzziness("AUTO") // 🔍 유사어 검색 허용 (예: 포트폴리오 ↔ 포트, 폴리오 등)
+            )
+        )
+        .size(100)
+        .build();
+
+    SearchResponse<Portfolio> response = elasticsearchClient.search(searchRequest, Portfolio.class);
+    return response.hits().hits().stream()
+        .map(Hit::source)
+        .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
## 🔥 PR 개요
Elasticsearch 인덱싱용 PortfolioDocument 도입 및 초기 색인 로직 추가

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
- PortfolioDocument 클래스를 도입하여 Elasticsearch에 저장할 포트폴리오 데이터 구조를 분리했습니다.
- PortfolioIndexer를 통해 애플리케이션 시작 시 모든 포트폴리오를 portfolios 인덱스에 색인합니다.
- LocalDateTime 타입 직렬화 오류를 해결하기 위해 ElasticsearchConfig에 JavaTimeModule이 포함된 커스텀 ObjectMapper를 등록했습니다.

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/50507616-2606-4b89-986b-26f3195dbffb)
![image](https://github.com/user-attachments/assets/e7f63aaf-0a82-4070-b2c5-d4a481aeeef4)

## 🏷️ 관련 이슈
#67 

## 🚀 추가 정보
리뷰어가 참고하면 좋을 추가적인 정보를 입력해주세요.
