### PR TITLE
feat: 검색 색인 자동화 및 gpt 토큰 초과 오류 해결

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/search/PortfolioSearchIndexer.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/search/PortfolioSearchIndexer.java
@@ -1,0 +1,39 @@
+package com.gitprism.GitPRism.portfolios.search;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.gitprism.GitPRism.portfolios.document.PortfolioDocument;
+import com.gitprism.GitPRism.portfolios.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PortfolioSearchIndexer {
+
+  private final ElasticsearchClient elasticsearchClient;
+
+  public void index(Portfolio portfolio) {
+    try {
+      PortfolioDocument doc = PortfolioDocument.builder()
+          .id(portfolio.getId())
+          .title(portfolio.getTitle())
+          .description(portfolio.getDescription())
+          .createdAt(portfolio.getCreatedAt())
+          .updatedAt(portfolio.getUpdatedAt())
+          .build();
+
+      elasticsearchClient.index(i -> i
+          .index("portfolios")
+          .id(doc.getId().toString())
+          .document(doc)
+      );
+
+      log.info("🔄 Elasticsearch 색인 완료: {}", doc.getTitle());
+
+    } catch (Exception e) {
+      log.error("❌ Elasticsearch 색인 실패 (portfolioId={}): {}", portfolio.getId(), e.getMessage());
+    }
+  }
+}

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/OpenAiService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/OpenAiService.java
@@ -28,25 +28,35 @@ public class OpenAiService {
 
     // ✅ PR 분석 요약 프롬프트
     public PrSummary summarizePr(String title, String body, String diff) {
+        // ✅ null 방어 처리
+        title = (title != null) ? title : "";
+        body = (body != null) ? body : "";
+        diff = (diff != null) ? diff : "";
+
+        // ✅ 토큰 초과 방지를 위한 길이 제한
+        if (title.length() > 300) title = title.substring(0, 300);
+        if (body.length() > 1500) body = body.substring(0, 1500);
+        if (diff.length() > 3000) diff = diff.substring(0, 3000);
+
         String prompt = """
-            아래는 GitHub Pull Request의 제목, 설명, 그리고 코드 변경(diff) 내용입니다.
-            이를 바탕으로 변경의 요지를 요약하고, 중요 코드 또는 기술 스택이 드러나는 부분이 있다면 함께 알려주세요.
+        아래는 GitHub Pull Request의 제목, 설명, 그리고 코드 변경(diff) 내용입니다.
+        이를 바탕으로 변경의 요지를 요약하고, 중요 코드 또는 기술 스택이 드러나는 부분이 있다면 함께 알려주세요.
 
-            출력 형식:
-            {
-              "summary": "...",
-              "importantCode": "..."
-            }
+        출력 형식:
+        {
+          "summary": "...",
+          "importantCode": "..."
+        }
 
-            PR 제목:
-            %s
+        PR 제목:
+        %s
 
-            PR 설명:
-            %s
+        PR 설명:
+        %s
 
-            코드 변경 내용 (diff):
-            %s
-            """.formatted(title, body, diff);
+        코드 변경 내용 (diff):
+        %s
+        """.formatted(title, body, diff);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + openAiApiKey);
@@ -55,8 +65,8 @@ public class OpenAiService {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("model", "gpt-3.5-turbo");
         requestBody.put("messages", List.of(
-                Map.of("role", "system", "content", "You are a professional software engineer helping write technical summaries."),
-                Map.of("role", "user", "content", prompt)
+            Map.of("role", "system", "content", "You are a professional software engineer helping write technical summaries."),
+            Map.of("role", "user", "content", prompt)
         ));
         requestBody.put("temperature", 0.7);
 
@@ -64,10 +74,10 @@ public class OpenAiService {
 
         try {
             ResponseEntity<Map> response = restTemplate.exchange(
-                    "https://api.openai.com/v1/chat/completions",
-                    HttpMethod.POST,
-                    request,
-                    Map.class
+                "https://api.openai.com/v1/chat/completions",
+                HttpMethod.POST,
+                request,
+                Map.class
             );
 
             Map<String, Object> responseBody = response.getBody();
@@ -76,19 +86,27 @@ public class OpenAiService {
                 if (!choices.isEmpty()) {
                     String content = (String) ((Map<String, Object>) choices.get(0).get("message")).get("content");
 
-                    // JSON 파싱
-                    Map<String, String> result = objectMapper.readValue(content, new TypeReference<>() {});
-                    return new PrSummary(title, body, result.get("summary"), result.get("importantCode"));
+                    try {
+                        Map<String, String> result = objectMapper.readValue(content, new TypeReference<>() {});
+                        return new PrSummary(title, body, result.get("summary"), result.get("importantCode"));
+                    } catch (Exception parseEx) {
+                        log.warn("❌ GPT 응답 JSON 파싱 실패 - 응답 원문:\n{}", content);
+                        throw new RuntimeException("OpenAI 응답 파싱 실패: " + parseEx.getMessage(), parseEx);
+                    }
                 }
             }
         } catch (HttpClientErrorException e) {
-            throw new RuntimeException("OpenAI 호출 실패: " + e.getMessage());
+            log.warn("❌ OpenAI 호출 실패 - 상태: {}, 응답 본문: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("OpenAI 호출 실패: " + e.getResponseBodyAsString(), e);
         } catch (Exception e) {
-            throw new RuntimeException("OpenAI 응답 파싱 실패: " + e.getMessage());
+            log.warn("❌ OpenAI 처리 중 예외 발생", e);
+            throw new RuntimeException("OpenAI 호출 또는 처리 중 예외 발생: " + e.getMessage(), e);
         }
 
         throw new RuntimeException("OpenAI 응답이 유효하지 않습니다.");
     }
+
+
 
     // 포트폴리오 생성용 프롬프트
     public String buildPortfolioPrompt(String stackList, String formattedSummaries) {

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -13,6 +13,7 @@ import com.gitprism.GitPRism.portfolios.dto.response.*;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio;
 import com.gitprism.GitPRism.portfolios.entity.Portfolio.Status;
 import com.gitprism.GitPRism.portfolios.repository.PortfolioRepository;
+import com.gitprism.GitPRism.portfolios.search.PortfolioSearchIndexer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PortfolioService {
 
+    private final PortfolioSearchIndexer portfolioSearchIndexer;
     private final CommentRepository commentRepository;
     private final BookmarkRepository bookmarkRepository;
     private final LikeRepository likeRepository;
@@ -90,7 +92,7 @@ public class PortfolioService {
                 .updatedAt(LocalDateTime.now())
                 .build();
         portfolioRepository.save(portfolio);
-
+        portfolioSearchIndexer.index(portfolio);
         PortfolioDetailDto detail = PortfolioDetailDto.builder()
                 .portfolioId(portfolio.getId())
                 .repoName(repo.getRepoName())
@@ -158,6 +160,7 @@ public class PortfolioService {
         combined.setDescription(summaryDescription);
         combined.setUpdatedAt(LocalDateTime.now());
         portfolioRepository.save(combined);
+        portfolioSearchIndexer.index(combined); // 추가
     }
 
 
@@ -262,7 +265,7 @@ public class PortfolioService {
         portfolio.setUpdatedAt(LocalDateTime.now());
 
         portfolioRepository.save(portfolio);
-
+        portfolioSearchIndexer.index(portfolio); // 추가
         String message = (newStatus == Status.PUBLISHED)
                 ? "포트폴리오가 성공적으로 게시되었습니다."
                 : "포트폴리오가 임시 저장되었습니다.";
@@ -314,6 +317,7 @@ public class PortfolioService {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
+        portfolioSearchIndexer.index(combined); // 추가
         return portfolioRepository.save(combined);
     }
 
@@ -342,7 +346,7 @@ public class PortfolioService {
 
         portfolio.setUpdatedAt(LocalDateTime.now());
         portfolioRepository.save(portfolio);
-
+        portfolioSearchIndexer.index(portfolio); // 추가
         Portfolio parent = portfolio.getParent();
         if (parent != null) {
             List<Portfolio> children = portfolioRepository.findByParentId(parent.getId());
@@ -354,6 +358,7 @@ public class PortfolioService {
             parent.setDescription(updatedDescription);
             parent.setUpdatedAt(LocalDateTime.now());
             portfolioRepository.save(parent);
+            portfolioSearchIndexer.index(parent); // 추가
         }
 
         PortfolioDetailDto detail = PortfolioDetailDto.fromEntity(portfolio);


### PR DESCRIPTION
## 🔥 PR 개요
- 검색 색인 자동화
- OpenAI 호출 시 Null 및 토큰 초과 대응 및 buildPortfolioPrompt 메서드 추가

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
- 검색 색인 자동화
- `OpenAiService.summarizePr()` 메서드에서 PR title, body, diff가 null이거나 과도하게 길 경우 예외가 발생하지 않도록 **방어 로직 추가**
  - `null -> ""` 처리
  - title: 300자, body: 1500자, diff: 3000자로 길이 제한
- 응답 파싱 실패 시 원본 로그 출력 및 예외 메시지 개선
- 예외 발생 시 log.warn을 통해 **OpenAI 응답 본문 출력 및 추적성 향상**
- 

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e6207318-7a8a-4285-9b75-88149c10f8a9)
![image](https://github.com/user-attachments/assets/767f3c81-264e-460f-af01-860911ec9262)

## 🏷️ 관련 이슈
#71 

