### PR TITLE
feat: 포트폴리오 조회 페이지 개수, 전체 포트폴리오 개수 응답값 추가

### DIFF
--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/dto/response/PortfolioBatchResponse.java
@@ -14,5 +14,10 @@ public class PortfolioBatchResponse {
     private String representativeImageUrl;
     private int code;
     private int count;
+    private int page;
+    private int pageSize;
+    private int totalPages;
+    private long totalCount;
+    private boolean hasNext;
     private List<PortfolioDetailDto> data;
 }

--- a/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
+++ b/GitPRism/src/main/java/com/gitprism/GitPRism/portfolios/service/PortfolioService.java
@@ -141,13 +141,18 @@ public class PortfolioService {
         String representativeImageUrl = results.isEmpty() ? null : results.get(0).getAvatarUrl();
 
         return new PortfolioBatchResponse(
-                "포트폴리오 %d개 생성 완료".formatted(results.size()),
-                combined.getId(),
-                representativeImageUrl,
-                201,
+                        "포트폴리오 %d개 생성 완료".formatted(results.size()),
+                        combined.getId(),
+                        representativeImageUrl,
+                        201,
+                        results.size(),
+                0,
                 results.size(),
+                1,
+                results.size(),
+                false,
                 results
-        );
+                );
     }
 
 
@@ -183,7 +188,6 @@ public class PortfolioService {
         boolean bookmarked = bookmarkRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
         boolean liked = likeRepository.existsByUserAndPortfolioAndIsDeletedFalse(user, portfolio);
 
-        // ✅ 하위 포트폴리오 조회
         List<Portfolio> children = portfolioRepository.findByParentId(portfolio.getId());
         List<SubPortfolioDto> data = children.stream()
                 .map(p -> SubPortfolioDto.builder()
@@ -245,13 +249,18 @@ public class PortfolioService {
                 .collect(Collectors.toList());
 
         return new PortfolioBatchResponse(
-                "내 포트폴리오 조회 성공",
-                null,
-                null,
-                200,
-                dtoList.size(),
+                        "내 포트폴리오 조회 성공",
+                        null,
+                        null,
+                        200,
+                        page.getNumberOfElements(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.hasNext(),
                 dtoList
-        );
+                );
     }
 
 
@@ -287,13 +296,18 @@ public class PortfolioService {
                 .collect(Collectors.toList());
 
         return new PortfolioBatchResponse(
-                "공개 포트폴리오 조회 성공",
-                null,
-                null,
-                200,
-                dtoList.size(),
+                        "공개 포트폴리오 조회 성공",
+                        null,
+                        null,
+                        200,
+                        page.getNumberOfElements(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.hasNext(),
                 dtoList
-        );
+                );
     }
 
 


### PR DESCRIPTION
## 🔥 PR 개요
포트폴리오 조회 api의 페이지 개수, 전체 포트폴리오 개수 응답값 추가

## 🎯 변경 사항
- [ ] 🐛 버그 수정 (Bug Fix)
- [ 0 ] 🔧 리팩토링 (Refactor)
- [ ] 🚀 기능 추가 (Feature)
- [ ] 🛠 기타 (Other)

## 💡 변경 내용
내 포트폴리오 조회와 전체 공개 포트폴리오 조회에 총 페이지 값(totalPages), 총 포트폴리오 개수 값 (totalCount) 추가

-전체 공개 포트폴리오 조회 응답값
![{FDDF56FF-4AF0-42EA-B704-724B12417E3F}](https://github.com/user-attachments/assets/9a496d0d-a5e4-4498-b6dd-645e9fd6e226)

-내 포트폴리오 조회 응답값
![{424EB99A-3701-4595-84BC-B790E3907151}](https://github.com/user-attachments/assets/484c84a1-2d20-4601-bd9d-61f3ee9a0b57)



## ✅ 테스트 방법
수정된 코드가 잘 작동하는지 테스트하는 방법을 설명해주세요.
- [ ] 유닛 테스트 실행 (`yarn test` 또는 `./gradlew test`)
- [ ] 직접 실행 후 UI 확인
- [ 0 ] Swagger으로 API 테스트

## 📷 스크린샷 (선택)
UI 변경이 있다면 스크린샷을 첨부해주세요.

## 🏷️ 관련 이슈
feat/#69

## 🚀 추가 정보
리뷰어가 참고하면 좋을 추가적인 정보를 입력해주세요.
